### PR TITLE
feat: add Documentation section with full SPECTRA docs

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Documentation"
+date: 2026-05-18
+description: "Official documentation for open-source security tools published by CybersecurityOS — built for practitioners, maintained in the open."
+draft: false
+---
+
+## CybersecurityOS Open Source Documentation
+
+This documentation covers open-source tools developed and maintained by CybersecurityOS. All projects are licensed under the Apache License 2.0 unless otherwise noted. Documentation is available under the Creative Commons Attribution 4.0 International License (CC BY 4.0).
+
+---
+
+### Projects
+
+| Project | Version | Description |
+|---|---|---|
+| [SPECTRA](/docs/spectra/) | v0.x (Beta) | AI-powered vulnerability triage CLI — transforms scanner output into ranked findings, attack chain analysis, and executive summaries |
+
+---
+
+### Principles
+
+Every tool published here is built around three commitments:
+
+1. **Free and open** — source code is publicly available and permissively licensed
+2. **Practitioner-first** — designed for working security teams, not proof-of-concept demos
+3. **AI-augmented, not AI-dependent** — AI accelerates the work; humans remain in control of the decisions
+
+---
+
+> For questions, issues, or contributions, visit the project repository on [GitHub](https://github.com/d0uble3L).

--- a/content/docs/spectra/_index.md
+++ b/content/docs/spectra/_index.md
@@ -1,0 +1,70 @@
+---
+title: "SPECTRA"
+date: 2026-05-18
+description: "SPECTRA — Security Platform for Expert-level Correlation, Triage, and Risk Analysis. Official open-source documentation."
+draft: false
+---
+
+## SPECTRA Documentation
+
+**SPECTRA** — _Security Platform for Expert-level Correlation, Triage, and Risk Analysis_ — is an open-source, AI-powered CLI that transforms raw scanner output into ranked findings, attack chain analysis, and executive summaries. Powered by [Claude](https://www.anthropic.com/).
+
+> **License:** Apache License 2.0
+> **Source:** [github.com/d0uble3L/spectra](https://github.com/d0uble3L/spectra)
+> **Status:** Beta — active development
+
+---
+
+### Documentation Sections
+
+| Section | Description |
+|---|---|
+| [Installation](/docs/spectra/installation/) | System requirements and install methods |
+| [Quick Start](/docs/spectra/quickstart/) | Run your first analysis in under 5 minutes |
+| [CLI Reference](/docs/spectra/cli-reference/) | Full command and flag reference |
+| [Configuration](/docs/spectra/configuration/) | Environment variables and `.env` setup |
+| [Supported Scanners](/docs/spectra/scanners/) | Trivy, Semgrep, Nessus, Burp Suite, and generic input |
+| [Output Formats](/docs/spectra/output-formats/) | Markdown, JSON, and report structure |
+| [CI/CD Integration](/docs/spectra/cicd-integration/) | GitHub Actions, GitLab CI, Jenkins |
+| [Architecture](/docs/spectra/architecture/) | Design decisions, prompt caching, and AI layer |
+| [Contributing](/docs/spectra/contributing/) | How to contribute, report issues, and request features |
+| [License](/docs/spectra/license/) | Apache 2.0 license, copyright, and trademark notice |
+
+---
+
+### What SPECTRA Does
+
+SPECTRA sits **downstream** of your existing security scanners. It does not replace them — it makes them actionable at scale.
+
+A single command:
+
+```bash
+spectra analyze trivy.json --format both --output reports/run1
+```
+
+Produces:
+
+- **Ranked findings** — calibrated by real-world risk, not raw CVSS scores
+- **Attack chain analysis** — connecting related vulnerabilities into exploitable paths  
+- **Executive summaries** — plain-language overviews ready for leadership or GRC audits
+- **Remediation guidance** — specific, contextual steps — not generic patch instructions
+
+---
+
+### Supported Scanners
+
+| Scanner | Input Format | Detection |
+|---|---|:---:|
+| [Trivy](https://trivy.dev/) | JSON | Automatic |
+| [Semgrep](https://semgrep.dev/) | JSON | Automatic |
+| Nessus / OpenVAS | Text | `--scanner generic` |
+| Burp Suite | Text export | `--scanner generic` |
+| Pentest notes | Plain text | `--scanner generic` |
+
+---
+
+### Copyright Notice
+
+Copyright © 2026 CybersecurityOS. All rights reserved.
+
+SPECTRA is distributed under the [Apache License 2.0](/docs/spectra/license/). The name "SPECTRA" and the CybersecurityOS wordmark are trademarks of CybersecurityOS and may not be used without prior written permission except as permitted by applicable trademark law.

--- a/content/docs/spectra/architecture.md
+++ b/content/docs/spectra/architecture.md
@@ -1,0 +1,133 @@
+---
+title: "Architecture"
+date: 2026-05-18
+description: "SPECTRA design decisions — prompt caching, AI layer, parser architecture, and data flow."
+draft: false
+weight: 80
+---
+
+## Architecture
+
+This page covers SPECTRA's internal design: how data flows through the system, how the AI layer works, and the key engineering decisions behind the implementation.
+
+---
+
+### High-Level Data Flow
+
+```
+Scanner Output (Trivy JSON / Semgrep JSON / plain text)
+        ↓
+    Parser Layer
+  (format detection + normalization)
+        ↓
+  Context Builder
+  (finding enrichment + chain detection input)
+        ↓
+  Claude API (with prompt caching)
+  (triage, attack chain analysis, executive summary)
+        ↓
+  Report Renderer
+  (Markdown + JSON output)
+        ↓
+  Output Files / stdout
+```
+
+---
+
+### Parser Layer
+
+SPECTRA includes a parser for each supported scanner format. Parsers normalize raw scanner output into a common internal schema before it reaches the AI layer:
+
+```python
+# Internal finding schema (simplified)
+{
+  "id": str,            # CVE ID, rule ID, or generated ID
+  "scanner": str,       # Source scanner type
+  "severity": str,      # normalized: critical/high/medium/low/informational
+  "title": str,
+  "description": str,
+  "affected": str,      # Package, file path, or host
+  "installed": str,     # Installed version (if applicable)
+  "fixed": str,         # Fixed version (if applicable)
+  "cvss_score": float,  # Raw CVSS if available
+  "raw": dict           # Original finding object from scanner
+}
+```
+
+This normalization layer is why SPECTRA can provide consistent analysis quality regardless of which scanner produced the input.
+
+---
+
+### AI Layer — Claude Integration
+
+The normalized findings are passed to Claude using a structured system prompt that encodes the security analyst role, prioritization criteria, and output format requirements.
+
+**Analyst system prompt responsibilities:**
+- Define the triage methodology (EPSS-weighted, attack-chain-aware, context-calibrated)
+- Specify output structure (executive summary, ranked findings, attack chains, remediation)
+- Set the audience model (engineer-level vs. CISO-level language calibration)
+
+**User message:**  
+The normalized findings JSON for the current scan run.
+
+**Model response:**  
+Structured analysis that is parsed back into the report schema.
+
+---
+
+### Prompt Caching
+
+SPECTRA uses [Claude's prompt caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) to make repeated analysis economically viable.
+
+The analyst system prompt — which is large and static — is cached after the first API call. Subsequent calls in the same session reuse the cached prefix, reducing:
+
+- **Latency** by ~30–50% on cache hits
+- **Cost** by approximately 90% for the cached portion of each request
+
+This is the mechanism that makes SPECTRA viable for continuous pipeline use at production scan volumes. Without caching, running analysis on every PR would be cost-prohibitive for most teams.
+
+**Cache behavior:**
+- Cache is populated on the first call with a given system prompt
+- The cache TTL is 5 minutes for standard caching; extended caching (up to 1 hour) is available with `cache_control: {"type": "ephemeral"}` on the system block
+- Token usage output (`--usage`) shows `cache_read_input_tokens` and `cache_creation_input_tokens` so you can monitor cache efficiency
+
+---
+
+### Attack Chain Detection
+
+Attack chain detection is performed by Claude during analysis, not by a separate rule engine. The prompt instructs Claude to:
+
+1. Identify findings that share a common host, service, or package scope
+2. Evaluate whether the findings could be sequentially exploited (e.g., unauthenticated RCE → privilege escalation → lateral movement)
+3. Assign a combined severity to the chain that may be higher than any individual finding's severity
+
+This approach is intentionally model-driven rather than rule-driven. Rule-based chain detection requires maintaining a library of attack patterns; model-driven detection generalizes across patterns the rules don't cover, including novel chains.
+
+---
+
+### Output Rendering
+
+After the AI layer returns a response, SPECTRA's renderer:
+
+1. Parses the structured response into the internal report schema
+2. Renders the Markdown report using a template engine
+3. Serializes the JSON report directly from the schema
+4. Writes outputs to the specified path
+
+The rendering layer is decoupled from the AI layer, making it straightforward to add new output formats (HTML, PDF, SARIF) without modifying the analysis pipeline.
+
+---
+
+### Design Principles
+
+**Upstream neutrality** — SPECTRA does not prescribe which scanners you use. Add or remove scanner integrations without changing the AI or rendering layers.
+
+**AI as analyst, not gatekeeper** — SPECTRA never blocks pipelines on its own judgment. It surfaces findings and analysis; humans and pipeline configuration decide what to do with them.
+
+**Minimal footprint** — SPECTRA has no persistent state, no database, and no required network services beyond the Anthropic API. It reads input, calls the API, and writes output. Nothing else.
+
+**Cost transparency** — The `--usage` flag exposes full token accounting so operators can track AI costs per scan and optimize accordingly.
+
+---
+
+**Next:** [Contributing →](/docs/spectra/contributing/)

--- a/content/docs/spectra/cicd-integration.md
+++ b/content/docs/spectra/cicd-integration.md
@@ -1,0 +1,193 @@
+---
+title: "CI/CD Integration"
+date: 2026-05-18
+description: "Integrate SPECTRA into GitHub Actions, GitLab CI, and Jenkins pipelines."
+draft: false
+weight: 70
+---
+
+## CI/CD Integration
+
+SPECTRA's CLI-first design makes it a natural fit in automated pipelines. This page covers integration patterns for GitHub Actions, GitLab CI, and Jenkins.
+
+---
+
+### General Principles
+
+1. **Inject `ANTHROPIC_API_KEY` as a repository secret** — never hard-code credentials in pipeline YAML
+2. **Use `--format json`** for machine-readable output and pipe to ticket creation or SIEM ingest
+3. **Use `--format both`** to preserve a human-readable artifact for security team review
+4. **Run SPECTRA after your scanner step**, not before — it consumes scanner output, not raw code
+
+---
+
+### GitHub Actions
+
+#### Trivy + SPECTRA in a PR check
+
+```yaml
+# .github/workflows/security-scan.yml
+name: Security Scan
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  spectra-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Trivy container scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ github.repository }}:${{ github.sha }}
+          format: json
+          output: trivy.json
+          exit-code: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install SPECTRA
+        run: |
+          git clone https://github.com/d0uble3L/spectra /tmp/spectra
+          pip install -e /tmp/spectra
+
+      - name: Run SPECTRA analysis
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          spectra analyze trivy.json --format both --output reports/pr-${{ github.event.pull_request.number }}
+
+      - name: Upload SPECTRA report
+        uses: actions/upload-artifact@v4
+        with:
+          name: spectra-report-pr-${{ github.event.pull_request.number }}
+          path: reports/
+          retention-days: 30
+```
+
+#### Semgrep + SPECTRA on push
+
+```yaml
+# .github/workflows/sast.yml
+name: SAST
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sast:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        run: |
+          pip install semgrep
+          semgrep --config=auto --json > semgrep.json
+
+      - name: Install SPECTRA
+        run: |
+          git clone https://github.com/d0uble3L/spectra /tmp/spectra
+          pip install -e /tmp/spectra
+
+      - name: Run SPECTRA analysis
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          cat semgrep.json | spectra analyze --scanner semgrep --format both --output reports/sast-${{ github.run_id }}
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: spectra-sast-${{ github.run_id }}
+          path: reports/
+```
+
+---
+
+### GitLab CI
+
+```yaml
+# .gitlab-ci.yml
+spectra-analysis:
+  stage: security
+  image: python:3.11-slim
+  before_script:
+    - apt-get update && apt-get install -y git
+    - git clone https://github.com/d0uble3L/spectra /tmp/spectra
+    - pip install -e /tmp/spectra
+  script:
+    - trivy image $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA -f json -o trivy.json
+    - spectra analyze trivy.json --format both --output reports/pipeline-$CI_PIPELINE_ID
+  artifacts:
+    paths:
+      - reports/
+    expire_in: 30 days
+  variables:
+    ANTHROPIC_API_KEY: $ANTHROPIC_API_KEY  # Set in GitLab CI/CD variables
+```
+
+---
+
+### Jenkins (Declarative Pipeline)
+
+```groovy
+// Jenkinsfile
+pipeline {
+    agent any
+    environment {
+        ANTHROPIC_API_KEY = credentials('anthropic-api-key')
+    }
+    stages {
+        stage('Trivy Scan') {
+            steps {
+                sh 'trivy image your-image:latest -f json -o trivy.json'
+            }
+        }
+        stage('SPECTRA Analysis') {
+            steps {
+                sh '''
+                    pip install -e /opt/spectra
+                    spectra analyze trivy.json --format both --output reports/build-${BUILD_NUMBER}
+                '''
+            }
+        }
+    }
+    post {
+        always {
+            archiveArtifacts artifacts: 'reports/**', allowEmptyArchive: true
+        }
+    }
+}
+```
+
+---
+
+### Secrets Management
+
+| Platform | How to add `ANTHROPIC_API_KEY` |
+|---|---|
+| GitHub Actions | Settings → Secrets and variables → Actions → New repository secret |
+| GitLab CI | Settings → CI/CD → Variables → Add variable |
+| Jenkins | Manage Jenkins → Credentials → Add Credentials (Secret text) |
+
+---
+
+### Recommended Pipeline Placement
+
+```
+Commit → Build → [ Trivy / Semgrep ] → SPECTRA → Report artifact → (optional) Ticket creation
+```
+
+SPECTRA runs after the scanner to analyze its output. It does not block the build by default — set your pipeline to fail on findings by parsing the JSON output for `critical` severity items if a gate is desired.
+
+---
+
+**Next:** [Architecture →](/docs/spectra/architecture/)

--- a/content/docs/spectra/cli-reference.md
+++ b/content/docs/spectra/cli-reference.md
@@ -1,0 +1,117 @@
+---
+title: "CLI Reference"
+date: 2026-05-18
+description: "Complete command and flag reference for the SPECTRA CLI."
+draft: false
+weight: 30
+---
+
+## CLI Reference
+
+Complete reference for all SPECTRA commands and flags.
+
+---
+
+### Global Usage
+
+```
+spectra [COMMAND] [OPTIONS] [INPUT]
+```
+
+---
+
+### Commands
+
+#### `spectra analyze`
+
+Analyze a scanner output file and produce ranked findings, attack chain analysis, and an executive summary.
+
+```
+spectra analyze [INPUT] [OPTIONS]
+```
+
+**Arguments**
+
+| Argument | Description |
+|---|---|
+| `INPUT` | Path to the scanner output file. Omit to read from stdin. |
+
+**Options**
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--scanner` | string | auto | Force scanner type: `trivy`, `semgrep`, `generic`. Auto-detected from file structure when omitted. |
+| `--format` | string | `markdown` | Output format: `markdown`, `json`, or `both`. |
+| `--output` | string | `./spectra_report` | Output file path, without extension. SPECTRA appends `.md` and/or `.json` depending on `--format`. |
+| `--usage` | flag | off | Print Anthropic API token usage stats after analysis. Useful for cost tracking. |
+| `--model` | string | `claude-sonnet-4-6` | Claude model to use. See [Configuration](/docs/spectra/configuration/) for supported models. |
+| `--max-tokens` | int | 4096 | Maximum tokens for the AI response. Increase for very large scan files. |
+| `--verbose` | flag | off | Enable verbose logging, including prompt and response details. |
+
+**Examples**
+
+```bash
+# Basic Trivy analysis, Markdown output
+spectra analyze trivy.json
+
+# Both output formats, custom output path
+spectra analyze trivy.json --format both --output reports/infra-scan-2026-05
+
+# Force generic scanner for pentest notes
+spectra analyze pentest.txt --scanner generic --format markdown --output reports/pt
+
+# Pipe Semgrep JSON from stdin
+cat semgrep.json | spectra analyze --scanner semgrep --format json --output reports/pr-42
+
+# Print token usage after analysis
+spectra analyze trivy.json --format both --output reports/run1 --usage
+```
+
+---
+
+#### `spectra --version`
+
+Print the installed SPECTRA version.
+
+```bash
+spectra --version
+```
+
+---
+
+#### `spectra --help`
+
+Print usage information.
+
+```bash
+spectra --help
+spectra analyze --help
+```
+
+---
+
+### Exit Codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Analysis completed successfully |
+| `1` | General error (invalid input, missing API key, etc.) |
+| `2` | API error (Anthropic rate limit, authentication failure) |
+
+---
+
+### Environment Variable Overrides
+
+All `--flag` options can also be set via environment variables, which take lower precedence than CLI flags:
+
+| Environment Variable | Equivalent Flag |
+|---|---|
+| `SPECTRA_SCANNER` | `--scanner` |
+| `SPECTRA_FORMAT` | `--format` |
+| `SPECTRA_OUTPUT` | `--output` |
+| `SPECTRA_MODEL` | `--model` |
+| `ANTHROPIC_API_KEY` | _(required)_ |
+
+---
+
+**Next:** [Configuration →](/docs/spectra/configuration/)

--- a/content/docs/spectra/configuration.md
+++ b/content/docs/spectra/configuration.md
@@ -1,0 +1,95 @@
+---
+title: "Configuration"
+date: 2026-05-18
+description: "Environment variables, .env setup, and model configuration for SPECTRA."
+draft: false
+weight: 40
+---
+
+## Configuration
+
+SPECTRA is configured through a `.env` file in the project root and optionally through environment variables set in the shell or CI/CD pipeline.
+
+---
+
+### `.env` File
+
+Copy the template and populate your values:
+
+```bash
+cp .env.example .env
+```
+
+A complete `.env` file looks like this:
+
+```bash
+# Required
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Optional — override defaults
+SPECTRA_MODEL=claude-sonnet-4-6
+SPECTRA_FORMAT=both
+SPECTRA_OUTPUT=reports/latest
+SPECTRA_MAX_TOKENS=4096
+```
+
+> Never commit `.env` to version control. It is listed in `.gitignore` by default.
+
+---
+
+### Required Variables
+
+| Variable | Description |
+|---|---|
+| `ANTHROPIC_API_KEY` | Your Anthropic API key. Obtain one at [console.anthropic.com](https://console.anthropic.com/). |
+
+---
+
+### Optional Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `SPECTRA_MODEL` | `claude-sonnet-4-6` | Claude model to use for analysis. See supported models below. |
+| `SPECTRA_FORMAT` | `markdown` | Default output format: `markdown`, `json`, or `both`. |
+| `SPECTRA_OUTPUT` | `./spectra_report` | Default output path prefix. |
+| `SPECTRA_MAX_TOKENS` | `4096` | Maximum response tokens. Increase for large scans. |
+| `SPECTRA_SCANNER` | _(auto)_ | Force scanner detection: `trivy`, `semgrep`, `generic`. |
+
+---
+
+### Supported Claude Models
+
+| Model | ID | Notes |
+|---|---|---|
+| Claude Sonnet 4.6 (default) | `claude-sonnet-4-6` | Best balance of speed and quality for most analysis workloads |
+| Claude Opus 4.7 | `claude-opus-4-7` | Highest quality — recommended for complex multi-scanner batch runs |
+| Claude Haiku 4.5 | `claude-haiku-4-5-20251001` | Fastest and lowest cost — suitable for high-volume pipeline use |
+
+Override the model per-run with the `--model` flag:
+
+```bash
+spectra analyze trivy.json --model claude-opus-4-7 --format both --output reports/deep-analysis
+```
+
+---
+
+### CI/CD Configuration
+
+In CI/CD environments, inject `ANTHROPIC_API_KEY` as a repository secret — do not store it in `.env` files committed to your repository.
+
+See [CI/CD Integration](/docs/spectra/cicd-integration/) for platform-specific examples.
+
+---
+
+### Configuration Precedence
+
+When the same option is set in multiple places, SPECTRA resolves in this order (highest to lowest):
+
+1. CLI flag (`--format`, `--output`, etc.)
+2. Shell environment variable
+3. `.env` file value
+4. Built-in default
+
+---
+
+**Next:** [Supported Scanners →](/docs/spectra/scanners/)

--- a/content/docs/spectra/contributing.md
+++ b/content/docs/spectra/contributing.md
@@ -1,0 +1,116 @@
+---
+title: "Contributing"
+date: 2026-05-18
+description: "How to contribute to SPECTRA — bug reports, feature requests, code contributions, and the contributor agreement."
+draft: false
+weight: 90
+---
+
+## Contributing to SPECTRA
+
+SPECTRA is an open-source project and contributions are welcome. This page covers how to report issues, submit pull requests, and what to expect from the review process.
+
+---
+
+### Ways to Contribute
+
+- **Bug reports** — Found something broken? Open an issue on GitHub
+- **Feature requests** — Have an idea? Open a discussion or issue with context on your use case
+- **New scanner parsers** — SPECTRA currently supports Trivy, Semgrep, and generic. Adding a new parser is one of the highest-value contributions
+- **Documentation improvements** — Clarifications, examples, and corrections are always welcome
+- **Test coverage** — Additional test cases for edge cases in scanner parsing or output rendering
+- **Security vulnerability reports** — See the [Security Policy](#security-policy) below
+
+---
+
+### Getting Started
+
+**1. Fork and clone the repository:**
+
+```bash
+git clone https://github.com/d0uble3L/spectra
+cd spectra
+```
+
+**2. Create a development environment:**
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+**3. Run the test suite:**
+
+```bash
+pytest tests/
+```
+
+**4. Create a branch for your change:**
+
+```bash
+git checkout -b feature/my-contribution
+```
+
+---
+
+### Contribution Guidelines
+
+**Code style:** SPECTRA uses `ruff` for linting and formatting. Run `ruff check .` and `ruff format .` before submitting.
+
+**Tests:** New parsers and features require test coverage. Use `tests/samples/` for sample scanner output files. Do not include real scan output from live systems.
+
+**Commit messages:** Use the imperative mood, present tense. Example: `Add Grype scanner parser` not `Added Grype scanner parser`.
+
+**Pull request scope:** Keep PRs focused on a single change. Large PRs are harder to review and slower to merge.
+
+---
+
+### Adding a New Scanner Parser
+
+The parser module lives in `spectra/parsers/`. Each parser:
+
+1. Receives raw scanner output (string or dict)
+2. Returns a list of normalized `Finding` objects using the internal schema
+3. Is registered in `spectra/parsers/__init__.py`
+
+A new parser should include:
+- Auto-detection logic (how SPECTRA recognizes this format without `--scanner`)
+- Normalization to the `Finding` schema
+- Sample output in `tests/samples/<scanner>/`
+- Unit tests in `tests/test_parsers.py`
+
+---
+
+### Reporting Bugs
+
+Open an issue at [github.com/d0uble3L/spectra/issues](https://github.com/d0uble3L/spectra/issues) and include:
+
+- SPECTRA version (`spectra --version`)
+- Operating system and Python version
+- The command you ran (with any sensitive data redacted)
+- The error output or unexpected behavior
+- A minimal reproduction case if possible
+
+---
+
+### Security Policy
+
+If you discover a security vulnerability in SPECTRA itself, **do not open a public GitHub issue.** Report it privately:
+
+- Email: [hello@cybersecurityos.net](mailto:hello@cybersecurityos.net)
+- Subject line: `[SPECTRA] Security Vulnerability Report`
+
+Include a description of the vulnerability, reproduction steps, and your assessment of severity. You will receive an acknowledgment within 48 hours.
+
+We follow responsible disclosure practices: we will coordinate a patch and public disclosure timeline with you before making any vulnerability public.
+
+---
+
+### Code of Conduct
+
+Contributors are expected to engage respectfully and professionally. Harassment, discrimination, or abuse of any kind will not be tolerated. Issues and pull requests that violate these expectations will be closed and the contributor may be blocked from the project.
+
+---
+
+**Next:** [License →](/docs/spectra/license/)

--- a/content/docs/spectra/installation.md
+++ b/content/docs/spectra/installation.md
@@ -1,0 +1,116 @@
+---
+title: "Installation"
+date: 2026-05-18
+description: "How to install SPECTRA — system requirements, pip install, Docker, and source build."
+draft: false
+weight: 10
+---
+
+## Installation
+
+SPECTRA runs anywhere Python 3.9+ is available. Three install paths are supported.
+
+---
+
+### System Requirements
+
+| Requirement | Minimum |
+|---|---|
+| Python | 3.9+ |
+| pip | 21.0+ |
+| Anthropic API key | Required ([get one here](https://console.anthropic.com/)) |
+| Operating system | Linux, macOS, Windows (WSL2 recommended) |
+| Memory | 512 MB RAM minimum |
+| Disk | 100 MB for source + dependencies |
+
+---
+
+### Option 1 — pip (Recommended)
+
+```bash
+git clone https://github.com/d0uble3L/spectra
+cd spectra
+pip install -e .
+```
+
+The `-e` flag installs in editable mode, making it easy to pull updates with `git pull` without reinstalling.
+
+Verify the install:
+
+```bash
+spectra --version
+```
+
+---
+
+### Option 2 — Docker
+
+No local Python environment required. Mount your scan files and receive reports in the `reports/` directory.
+
+```bash
+# Pull and run a one-off analysis
+docker compose run --rm analyze scans/trivy.json --format both --output /app/reports/out
+```
+
+Build the image locally from source:
+
+```bash
+git clone https://github.com/d0uble3L/spectra
+cd spectra
+docker build -t spectra .
+docker run --rm \
+  -v $(pwd)/scans:/app/scans \
+  -v $(pwd)/reports:/app/reports \
+  --env-file .env \
+  spectra analyze scans/trivy.json --format both --output /app/reports/out
+```
+
+---
+
+### Option 3 — Source (development)
+
+```bash
+git clone https://github.com/d0uble3L/spectra
+cd spectra
+python -m venv .venv
+source .venv/bin/activate    # Windows: .venv\Scripts\activate
+pip install -e ".[dev]"
+```
+
+The `[dev]` extras install test dependencies (`pytest`, `ruff`, `mypy`).
+
+---
+
+### Environment Setup
+
+SPECTRA reads credentials from a `.env` file in the project root.
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` and add your Anthropic API key:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Keep this file out of version control — it is already listed in `.gitignore`.
+
+> For CI/CD environments, inject `ANTHROPIC_API_KEY` as a repository secret rather than committing a `.env` file. See [CI/CD Integration](/docs/spectra/cicd-integration/) for details.
+
+---
+
+### Verifying the Installation
+
+Run SPECTRA against the bundled sample file to confirm everything works:
+
+```bash
+spectra analyze tests/samples/trivy_sample.json
+```
+
+A successful run prints a ranked finding summary to stdout and writes reports to the current directory.
+
+---
+
+**Next:** [Quick Start →](/docs/spectra/quickstart/)

--- a/content/docs/spectra/license.md
+++ b/content/docs/spectra/license.md
@@ -1,0 +1,112 @@
+---
+title: "License"
+date: 2026-05-18
+description: "SPECTRA license, copyright, trademark, and IP notices."
+draft: false
+weight: 100
+---
+
+## License and Legal Notices
+
+---
+
+### Software License — Apache License 2.0
+
+SPECTRA is licensed under the **Apache License, Version 2.0**.
+
+```
+Copyright 2026 CybersecurityOS
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
+The full license text is available at [apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0) and in the `LICENSE` file in the project repository.
+
+---
+
+### What the Apache 2.0 License Permits
+
+| You may | Condition |
+|---|---|
+| Use SPECTRA commercially | No restrictions |
+| Modify SPECTRA | Must preserve copyright and license notices |
+| Distribute SPECTRA | Must include the Apache 2.0 license |
+| Distribute modified versions | Must state changes made; must include the Apache 2.0 license |
+| Use privately without disclosure | No requirement to open-source modifications used internally |
+| Sublicense | Permitted under Apache 2.0 terms |
+
+The Apache License 2.0 also includes an **express patent license grant** from all contributors — meaning contributors grant you a license to any patents they hold that are necessarily infringed by their contribution. This is the primary protection the Apache 2.0 license provides beyond the MIT License.
+
+---
+
+### Documentation License — CC BY 4.0
+
+This documentation (the content at [cybersecurityos.net/docs/](https://cybersecurityos.net/docs/)) is licensed under the **Creative Commons Attribution 4.0 International License (CC BY 4.0)**.
+
+You are free to share and adapt this documentation for any purpose, including commercial, as long as you provide appropriate attribution to CybersecurityOS.
+
+Full license: [creativecommons.org/licenses/by/4.0](https://creativecommons.org/licenses/by/4.0/)
+
+---
+
+### Trademark Notice
+
+The name **SPECTRA**, the phrase **Security Platform for Expert-level Correlation, Triage, and Risk Analysis**, and the **CybersecurityOS** wordmark are trademarks of CybersecurityOS.
+
+The Apache License grants you rights to the software code. It does **not** grant rights to use these trademarks to:
+
+- Name or brand a fork of SPECTRA in a way that implies official affiliation
+- Use the CybersecurityOS name or logo in any promotional material without prior written permission
+
+To request trademark use, contact [legal@cybersecurityos.net](mailto:legal@cybersecurityos.net).
+
+---
+
+### Attribution Requirements
+
+When redistributing SPECTRA or its documentation, include the following attribution:
+
+```
+SPECTRA — Security Platform for Expert-level Correlation, Triage, and Risk Analysis
+Copyright 2026 CybersecurityOS
+Licensed under the Apache License, Version 2.0
+https://github.com/d0uble3L/spectra
+```
+
+---
+
+### Third-Party Dependencies
+
+SPECTRA depends on third-party open-source packages. Their licenses are included in the `NOTICE` file in the project repository. All dependencies are compatible with the Apache 2.0 license.
+
+Key dependencies include:
+
+| Package | License |
+|---|---|
+| `anthropic` (Anthropic SDK) | MIT |
+| `click` (CLI framework) | BSD-3-Clause |
+| `rich` (terminal formatting) | MIT |
+| `pydantic` (data validation) | MIT |
+| `python-dotenv` (env file loading) | BSD-3-Clause |
+
+---
+
+### No Warranty
+
+SPECTRA is provided "as is" without warranty of any kind. CybersecurityOS makes no representations or guarantees regarding the accuracy, completeness, or fitness for purpose of the analysis SPECTRA produces. AI-generated security analysis should be reviewed by qualified security professionals before action is taken. Do not rely solely on SPECTRA output for critical security decisions.
+
+---
+
+### Questions
+
+For licensing questions, contact [legal@cybersecurityos.net](mailto:legal@cybersecurityos.net).

--- a/content/docs/spectra/output-formats.md
+++ b/content/docs/spectra/output-formats.md
@@ -1,0 +1,162 @@
+---
+title: "Output Formats"
+date: 2026-05-18
+description: "SPECTRA output formats — Markdown, JSON, and report structure reference."
+draft: false
+weight: 60
+---
+
+## Output Formats
+
+SPECTRA produces two output formats: **Markdown** (human-readable) and **JSON** (machine-readable for downstream tooling). Use `--format both` to generate both simultaneously.
+
+---
+
+### Format Options
+
+| Value | Files Generated | Use Case |
+|---|---|---|
+| `markdown` (default) | `<output>.md` | Reports, executive briefings, GRC documentation |
+| `json` | `<output>.json` | SIEM integration, ticketing automation, dashboards |
+| `both` | `<output>.md` + `<output>.json` | Full reporting + downstream automation |
+
+```bash
+spectra analyze trivy.json --format both --output reports/scan-2026-05-18
+# Writes: reports/scan-2026-05-18.md
+#         reports/scan-2026-05-18.json
+```
+
+---
+
+### Markdown Report Structure
+
+The Markdown report is structured for human review and is suitable for sharing directly with engineers, analysts, and leadership.
+
+```
+# SPECTRA Analysis Report
+Generated: 2026-05-18T14:32:00Z
+Scanner: Trivy | Findings: 47 | Critical: 3 | High: 11
+
+---
+
+## Executive Summary
+
+[Plain-language summary of the scan results, overall risk posture,
+and recommended priority actions. Written for non-technical leadership.]
+
+---
+
+## Attack Chain Analysis
+
+[AI-identified vulnerability chains that form exploitable paths.
+Each chain lists the constituent CVEs/findings, the attack vector,
+and the resulting blast radius if exploited.]
+
+### Chain 1: Container Escape via CVE-2024-XXXX → Lateral Movement
+
+...
+
+---
+
+## Ranked Findings
+
+### Critical
+
+#### CVE-2024-XXXX — [Package Name] [Version]
+- **CVSS Score:** 9.8
+- **EPSS Probability:** 0.87 (87th percentile)
+- **Context:** Exploitable without authentication via network vector
+- **Remediation:** Upgrade [package] to [fixed-version]
+
+...
+
+### High
+
+...
+
+---
+
+## Remediation Summary
+
+| Finding | Severity | Remediation | Effort |
+|---|---|---|---|
+| CVE-XXXX | Critical | Upgrade package X to 1.2.3 | Low |
+...
+```
+
+---
+
+### JSON Report Structure
+
+The JSON report exposes all analysis fields in a structured format for integration with ticketing systems, SIEM platforms, and dashboards.
+
+```json
+{
+  "meta": {
+    "spectra_version": "0.x",
+    "generated_at": "2026-05-18T14:32:00Z",
+    "scanner": "trivy",
+    "model": "claude-sonnet-4-6",
+    "total_findings": 47
+  },
+  "executive_summary": "...",
+  "attack_chains": [
+    {
+      "id": "chain-1",
+      "title": "Container Escape via CVE-2024-XXXX",
+      "severity": "critical",
+      "cve_ids": ["CVE-2024-XXXX", "CVE-2024-YYYY"],
+      "description": "...",
+      "blast_radius": "..."
+    }
+  ],
+  "findings": [
+    {
+      "id": "CVE-2024-XXXX",
+      "package": "package-name",
+      "installed_version": "1.0.0",
+      "fixed_version": "1.2.3",
+      "severity": "critical",
+      "cvss_score": 9.8,
+      "epss_probability": 0.87,
+      "ai_risk_context": "...",
+      "remediation": "...",
+      "attack_chain_ids": ["chain-1"]
+    }
+  ],
+  "token_usage": {
+    "input_tokens": 12450,
+    "output_tokens": 1820,
+    "cache_read_tokens": 9800,
+    "cache_write_tokens": 2650
+  }
+}
+```
+
+---
+
+### Integrating JSON Output
+
+**Jira (example):**
+
+```bash
+# Parse critical findings and create tickets
+spectra analyze trivy.json --format json --output /tmp/report
+jq '.findings[] | select(.severity == "critical")' /tmp/report.json \
+  | your-jira-ticket-script
+```
+
+**Slack notification:**
+
+```bash
+SUMMARY=$(jq -r '.executive_summary' /tmp/report.json)
+curl -X POST $SLACK_WEBHOOK -d "{\"text\": \"SPECTRA scan complete:\\n${SUMMARY}\"}"
+```
+
+**SIEM ingest:**
+
+The JSON structure is flat enough to ingest directly into Elasticsearch, Splunk, or any SIEM that accepts structured JSON. Map `findings[].id` as the document ID to support deduplication across scan runs.
+
+---
+
+**Next:** [CI/CD Integration →](/docs/spectra/cicd-integration/)

--- a/content/docs/spectra/quickstart.md
+++ b/content/docs/spectra/quickstart.md
@@ -1,0 +1,104 @@
+---
+title: "Quick Start"
+date: 2026-05-18
+description: "Run your first SPECTRA analysis in under 5 minutes."
+draft: false
+weight: 20
+---
+
+## Quick Start
+
+This guide gets you from install to your first analysis in under 5 minutes. It assumes you have already completed [Installation](/docs/spectra/installation/).
+
+---
+
+### Step 1 — Set your API key
+
+```bash
+cp .env.example .env
+# Edit .env and add your Anthropic API key
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+---
+
+### Step 2 — Run your first analysis
+
+Use the bundled Trivy sample to confirm the setup:
+
+```bash
+spectra analyze tests/samples/trivy_sample.json
+```
+
+SPECTRA auto-detects the scanner type from the file structure and outputs a ranked summary to stdout.
+
+---
+
+### Step 3 — Analyze your own scanner output
+
+**Trivy (container or filesystem scan):**
+
+```bash
+# Generate a Trivy scan first
+trivy image your-image:latest -f json -o trivy.json
+
+# Analyze with SPECTRA
+spectra analyze trivy.json --format both --output reports/run1
+```
+
+**Semgrep (SAST):**
+
+```bash
+# Generate a Semgrep scan
+semgrep --config=auto --json > semgrep.json
+
+# Pipe directly into SPECTRA
+cat semgrep.json | spectra analyze --scanner semgrep --format json --output reports/pr-check
+```
+
+**Generic / pentest notes / Nessus:**
+
+```bash
+spectra analyze nessus_export.txt --scanner generic --format markdown --output reports/pentest
+```
+
+---
+
+### Step 4 — Review outputs
+
+By default, SPECTRA writes reports to the path specified in `--output`:
+
+```
+reports/run1.md      ← Human-readable ranked summary
+reports/run1.json    ← Structured JSON for downstream tooling
+```
+
+Open the Markdown report to see:
+
+- **Executive summary** — plain-language overview for leadership
+- **Ranked findings** — severity-ordered with contextual risk notes
+- **Attack chains** — connected vulnerability paths
+- **Remediation steps** — specific guidance per finding
+
+---
+
+### Common Options at a Glance
+
+| Flag | Description | Example |
+|---|---|---|
+| `--format` | Output format: `markdown`, `json`, or `both` | `--format both` |
+| `--output` | Output file path (no extension needed) | `--output reports/scan1` |
+| `--scanner` | Force scanner type: `trivy`, `semgrep`, `generic` | `--scanner generic` |
+| `--usage` | Print token usage stats after analysis | `--usage` |
+
+---
+
+### Next Steps
+
+- [CLI Reference](/docs/spectra/cli-reference/) — full flag and command reference
+- [Configuration](/docs/spectra/configuration/) — tune model behavior and output defaults
+- [CI/CD Integration](/docs/spectra/cicd-integration/) — add SPECTRA to your pipeline
+
+---
+
+**Next:** [CLI Reference →](/docs/spectra/cli-reference/)

--- a/content/docs/spectra/scanners.md
+++ b/content/docs/spectra/scanners.md
@@ -1,0 +1,141 @@
+---
+title: "Supported Scanners"
+date: 2026-05-18
+description: "Scanner input formats supported by SPECTRA — Trivy, Semgrep, Nessus, Burp Suite, and generic text."
+draft: false
+weight: 50
+---
+
+## Supported Scanners
+
+SPECTRA processes output from the following scanner types. Auto-detection is attempted by default; use `--scanner` to force a specific parser when auto-detection does not apply.
+
+---
+
+### Trivy
+
+[Trivy](https://trivy.dev/) is an open-source vulnerability scanner for containers, filesystems, Git repositories, and cloud infrastructure.
+
+**Auto-detected:** Yes — from JSON structure  
+**Input format:** JSON (`-f json`)
+
+**Generate scan output:**
+
+```bash
+# Container image scan
+trivy image your-image:latest -f json -o trivy.json
+
+# Filesystem scan
+trivy fs . -f json -o trivy-fs.json
+
+# Kubernetes scan
+trivy k8s --report summary -f json -o trivy-k8s.json
+```
+
+**Analyze with SPECTRA:**
+
+```bash
+spectra analyze trivy.json --format both --output reports/container-scan
+```
+
+**What SPECTRA extracts from Trivy output:**
+
+- CVE identifiers, CVSS scores, and severity ratings
+- Affected package names and installed versions
+- Fixed versions (when available)
+- Vulnerability descriptions for AI contextualization
+
+---
+
+### Semgrep
+
+[Semgrep](https://semgrep.dev/) is a static analysis tool for finding bugs, security vulnerabilities, and code quality issues.
+
+**Auto-detected:** Yes — from JSON structure  
+**Input format:** JSON (`--json`)
+
+**Generate scan output:**
+
+```bash
+# Run with default security ruleset
+semgrep --config=auto --json > semgrep.json
+
+# Run with a specific ruleset
+semgrep --config=p/owasp-top-ten --json > semgrep-owasp.json
+```
+
+**Analyze with SPECTRA:**
+
+```bash
+# From file
+spectra analyze semgrep.json --format both --output reports/sast-scan
+
+# From stdin (useful in CI pipelines)
+semgrep --config=auto --json | spectra analyze --scanner semgrep --format json --output reports/pr-check
+```
+
+**What SPECTRA extracts from Semgrep output:**
+
+- Rule IDs and CWE mappings
+- File paths and line numbers for each finding
+- Severity levels and confidence ratings
+- Code snippets for contextual analysis
+
+---
+
+### Generic / Nessus / OpenVAS / Burp Suite
+
+The generic scanner mode accepts unstructured text-based output from tools that do not export a parseable JSON format, including:
+
+- [Nessus](https://www.tenable.com/products/nessus) exports
+- [OpenVAS](https://www.openvas.org/) reports
+- [Burp Suite](https://portswigger.net/burp) HTML or text exports
+- Pentest notes and manual findings
+
+**Auto-detected:** No — must specify `--scanner generic`  
+**Input format:** Plain text or HTML
+
+**Analyze with SPECTRA:**
+
+```bash
+# Nessus text export
+spectra analyze nessus_report.txt --scanner generic --format both --output reports/nessus
+
+# Burp Suite export
+spectra analyze burp_export.txt --scanner generic --format markdown --output reports/burp
+
+# Pentest notes
+spectra analyze pentest_notes.txt --scanner generic --format both --output reports/engagement-1
+```
+
+**Guidance for generic input quality:**
+
+The AI analysis quality scales with input structure. For best results with generic input:
+
+- Include CVE identifiers where available
+- Note host/IP context for each finding
+- List affected service or component names
+- Include severity ratings from the source tool
+
+---
+
+### Adding New Scanners
+
+SPECTRA is open to contributions that add parsers for additional scanner formats. See [Contributing](/docs/spectra/contributing/) for the contribution process and the project repository for the `parsers/` module structure.
+
+---
+
+### Scanner Comparison
+
+| Feature | Trivy | Semgrep | Generic |
+|---|---|---|---|
+| Auto-detection | ✓ | ✓ | — |
+| JSON structured input | ✓ | ✓ | — |
+| CVE mapping | ✓ | ✓ (CWE) | Depends on input |
+| SAST findings | — | ✓ | ✓ |
+| Infrastructure/container | ✓ | — | ✓ |
+| Pentest notes | — | — | ✓ |
+
+---
+
+**Next:** [Output Formats →](/docs/spectra/output-formats/)

--- a/hugo.toml
+++ b/hugo.toml
@@ -44,6 +44,11 @@ googleAnalytics = "YOUR_TRACKING_ID"  # Replace with your Google Analytics track
   weight = 2
 
 [[menu.main]]
+  name = "Docs"
+  url = "/docs/"
+  weight = 3
+
+[[menu.main]]
   name = "Store"
   url = "https://store.cybersecurityos.net/"
   weight = 4


### PR DESCRIPTION
## Summary

- Adds a **Docs** nav tab to the site (weight 3, between Posts and Store)
- Creates a full `content/docs/spectra/` documentation section (11 pages) as the first entry in the new docs hub
- Security disclosure contact updated to `hello@cybersecurityos.net`

## Pages added

| Page | Path |
|---|---|
| Docs landing | `/docs/` |
| SPECTRA overview | `/docs/spectra/` |
| Installation | `/docs/spectra/installation/` |
| Quick Start | `/docs/spectra/quickstart/` |
| CLI Reference | `/docs/spectra/cli-reference/` |
| Configuration | `/docs/spectra/configuration/` |
| Supported Scanners | `/docs/spectra/scanners/` |
| Output Formats | `/docs/spectra/output-formats/` |
| CI/CD Integration | `/docs/spectra/cicd-integration/` |
| Architecture | `/docs/spectra/architecture/` |
| Contributing | `/docs/spectra/contributing/` |
| License | `/docs/spectra/license/` |

## IP / Legal

- Licensed under **Apache License 2.0** (includes express patent grant)
- Documentation under **CC BY 4.0**
- "SPECTRA" and "CybersecurityOS" trademark notices explicitly carved out from the Apache grant
- No-warranty clause on AI-generated analysis output
- Private security disclosure via `hello@cybersecurityos.net`

## Test plan

- [ ] Verify "Docs" appears in site nav
- [ ] Verify `/docs/` landing page renders
- [ ] Verify `/docs/spectra/` and all sub-pages render
- [ ] Verify internal doc links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)