### PR TITLE
feat: futuristic dark theme redesign + founding member page

### DIFF
--- a/content/founding-member.md
+++ b/content/founding-member.md
@@ -1,0 +1,7 @@
+---
+title: "Founding Member"
+description: "Join CybersecurityOS as a Founding Member. Three tiers built for security engineers, leaders, and career climbers — from free weekly intelligence to hands-on async strategy."
+layout: "founding-member"
+draft: false
+slug: "founding-member"
+---

--- a/hugo.toml
+++ b/hugo.toml
@@ -58,6 +58,11 @@ googleAnalytics = "YOUR_TRACKING_ID"  # Replace with your Google Analytics track
   url = "/contact/"
   weight = 5
 
+[[menu.main]]
+  name = "Membership"
+  url = "/founding-member/"
+  weight = 6
+
 # Enable the sitemap
 [params.sitemap]
   sitemap = true

--- a/layouts/_default/founding-member.html
+++ b/layouts/_default/founding-member.html
@@ -1,0 +1,844 @@
+{{ define "header" }}
+  {{ partial "site-header.html" . }}
+{{ end }}
+
+{{ define "main" }}
+<div class="fm-page">
+
+  <!-- ═══ HERO ══════════════════════════════════════════════════ -->
+  <section class="fm-hero">
+    <div class="fm-hero-grid" aria-hidden="true"></div>
+    <div class="fm-hero-glow" aria-hidden="true"></div>
+    <div class="fm-hero-content">
+      <div class="fm-eyebrow">
+        <span class="fm-dot"></span>
+        Founding Member Access — Launch Pricing
+      </div>
+      <h1 class="fm-title">
+        Join the OS.<br>
+        <span>Get the Edge.</span>
+      </h1>
+      <p class="fm-subtitle">
+        Weekly security intelligence, leadership frameworks, and systems thinking
+        for security engineers and CISOs — from free reader to full OS access.
+        <strong>Founding member rates are locked in for life.</strong>
+      </p>
+      <div class="fm-hero-badges">
+        <span class="fm-badge fm-badge--green">18+ posts published</span>
+        <span class="fm-badge fm-badge--purple">SPECTRA open-source</span>
+        <span class="fm-badge fm-badge--blue">Deputy CISO author</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ PRICING CARDS ════════════════════════════════════════ -->
+  <section class="fm-pricing-section">
+    <div class="fm-section-label">// Select your tier</div>
+    <div class="fm-cards">
+
+      <!-- ── TIER 1: FREE ──────────────────────────────────── -->
+      <div class="fm-card">
+        <div class="fm-card-header">
+          <span class="fm-tier-badge fm-tier-badge--free">Free</span>
+          <h2 class="fm-card-name">Reader</h2>
+          <div class="fm-price">
+            <span class="fm-price-amount">$0</span>
+            <span class="fm-price-cadence">always free</span>
+          </div>
+          <p class="fm-card-desc">
+            The CybersecurityOS weekly feed — no paywall, no expiry.
+          </p>
+        </div>
+        <ul class="fm-features">
+          <li class="fm-feature">
+            <span class="fm-check">✓</span>
+            Weekly OS post — threat intel, mental models, leadership
+          </li>
+          <li class="fm-feature">
+            <span class="fm-check">✓</span>
+            SPECTRA and product release notes
+          </li>
+          <li class="fm-feature">
+            <span class="fm-check">✓</span>
+            All public content and docs
+          </li>
+          <li class="fm-feature fm-feature--dim">
+            <span class="fm-cross">✗</span>
+            Vault access
+          </li>
+          <li class="fm-feature fm-feature--dim">
+            <span class="fm-cross">✗</span>
+            Monthly deep-dives
+          </li>
+          <li class="fm-feature fm-feature--dim">
+            <span class="fm-cross">✗</span>
+            Async Q&A
+          </li>
+        </ul>
+        <div class="fm-card-footer">
+          <a href="/posts/" class="fm-btn fm-btn--ghost">
+            Read the OS →
+          </a>
+        </div>
+      </div>
+
+      <!-- ── TIER 2: OS MEMBER ─────────────────────────────── -->
+      <div class="fm-card fm-card--featured">
+        <div class="fm-popular-badge">Most Popular</div>
+        <div class="fm-card-header">
+          <span class="fm-tier-badge fm-tier-badge--member">Founding Member</span>
+          <h2 class="fm-card-name">OS Member</h2>
+          <div class="fm-price">
+            <span class="fm-price-amount">$15</span>
+            <span class="fm-price-cadence">/month</span>
+          </div>
+          <div class="fm-price-alt">or $120/year <span class="fm-save-badge">Save $60</span></div>
+          <p class="fm-card-desc">
+            Full OS access — built for security engineers who want to lead,
+            not just react.
+          </p>
+        </div>
+        <ul class="fm-features">
+          <li class="fm-feature">
+            <span class="fm-check fm-check--green">✓</span>
+            Everything in Reader
+          </li>
+          <li class="fm-feature">
+            <span class="fm-check fm-check--green">✓</span>
+            Vault access — full archive of frameworks, templates, playbooks
+          </li>
+          <li class="fm-feature">
+            <span class="fm-check fm-check--green">✓</span>
+            Monthly deep-dive — long-form analysis on one security domain
+          </li>
+          <li class="fm-feature">
+            <span class="fm-check fm-check--green">✓</span>
+            Async Q&A — submit questions, get real answers
+          </li>
+          <li class="fm-feature fm-feature--dim">
+            <span class="fm-cross">✗</span>
+            Private community channel
+          </li>
+          <li class="fm-feature fm-feature--dim">
+            <span class="fm-cross">✗</span>
+            Async strategy review
+          </li>
+        </ul>
+        <div class="fm-card-footer">
+          <a href="https://store.cybersecurityos.net/l/os-member" class="fm-btn fm-btn--primary" target="_blank" rel="noopener">
+            Join as Founding Member →
+          </a>
+          <p class="fm-cta-note">Rate locked in for life · Cancel any time</p>
+        </div>
+      </div>
+
+      <!-- ── TIER 3: OS PRO ────────────────────────────────── -->
+      <div class="fm-card fm-card--future">
+        <div class="fm-coming-badge">Coming Soon</div>
+        <div class="fm-card-header">
+          <span class="fm-tier-badge fm-tier-badge--pro">Future</span>
+          <h2 class="fm-card-name">OS Pro</h2>
+          <div class="fm-price">
+            <span class="fm-price-amount">$49</span>
+            <span class="fm-price-cadence">/month</span>
+          </div>
+          <p class="fm-card-desc">
+            For security leaders who want direct access — strategy reviews,
+            private community, and advisory-level depth.
+          </p>
+        </div>
+        <ul class="fm-features">
+          <li class="fm-feature">
+            <span class="fm-check fm-check--purple">✓</span>
+            Everything in OS Member
+          </li>
+          <li class="fm-feature">
+            <span class="fm-check fm-check--purple">✓</span>
+            Private Slack / Discord channel — peers + author access
+          </li>
+          <li class="fm-feature">
+            <span class="fm-check fm-check--purple">✓</span>
+            1× async strategy review/month — program, career, or risk question
+          </li>
+          <li class="fm-feature fm-feature--dim">
+            <span class="fm-cross">✗</span>
+            Not yet available
+          </li>
+        </ul>
+        <div class="fm-card-footer">
+          <a href="#notify" class="fm-btn fm-btn--ghost fm-btn--disabled" aria-disabled="true">
+            Notify Me When Live
+          </a>
+          <p class="fm-cta-note">Join OS Member to be first in line</p>
+        </div>
+      </div>
+
+    </div><!-- /fm-cards -->
+  </section>
+
+  <!-- ═══ FOUNDING MEMBER CALLOUT ══════════════════════════════ -->
+  <section class="fm-callout">
+    <div class="fm-callout-inner">
+      <div class="fm-callout-icon">⚡</div>
+      <div>
+        <h3 class="fm-callout-title">Why "Founding Member"?</h3>
+        <p class="fm-callout-body">
+          The first cohort who join at $15/month lock in that rate permanently —
+          even when pricing increases as the vault grows. You're not just
+          subscribing. You're co-signing that security engineers deserve
+          better intelligence infrastructure.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ WHAT'S IN THE VAULT ══════════════════════════════════ -->
+  <section class="fm-vault-section">
+    <div class="fm-section-label">// What's inside the vault</div>
+    <h2 class="fm-section-title">Everything a security engineer needs to lead</h2>
+    <div class="fm-vault-grid">
+      <div class="fm-vault-item">
+        <span class="fm-vault-icon">🧠</span>
+        <h4>Mental Models</h4>
+        <p>30+ decision frameworks used at the CISO and deputy-CISO level. Detect, Disengage, Shield. Flywheel vs. Fire Station. Hazard + Outrage.</p>
+      </div>
+      <div class="fm-vault-item">
+        <span class="fm-vault-icon">🗂</span>
+        <h4>Playbooks & Templates</h4>
+        <p>Incident response runbooks, risk register templates, audit readiness checklists, SOC 2 / ISO 27001 control mappings.</p>
+      </div>
+      <div class="fm-vault-item">
+        <span class="fm-vault-icon">🛡</span>
+        <h4>Threat Intelligence</h4>
+        <p>Curated weekly signal — CVE prioritization, campaign analysis, and the context that turns noise into decisions.</p>
+      </div>
+      <div class="fm-vault-item">
+        <span class="fm-vault-icon">🚀</span>
+        <h4>Career Frameworks</h4>
+        <p>Engineer → Leader transition maps, executive communication templates, and the 8 shifts that separate senior engineers from security leaders.</p>
+      </div>
+      <div class="fm-vault-item">
+        <span class="fm-vault-icon">🤖</span>
+        <h4>AI & Automation</h4>
+        <p>Claude prompts for security workflows, SPECTRA integration guides, agentic SOC patterns, and GRC engineering blueprints.</p>
+      </div>
+      <div class="fm-vault-item">
+        <span class="fm-vault-icon">📊</span>
+        <h4>GRC & Compliance</h4>
+        <p>Audit season guides for SOC 2, ISO 27001, and NIST. Risk management OS templates. Board-ready security metric frameworks.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ AUTHOR CREDIBILITY ═══════════════════════════════════ -->
+  <section class="fm-author">
+    <div class="fm-author-inner">
+      <div class="fm-author-meta">
+        <p class="fm-author-label">// Written and curated by</p>
+        <h3 class="fm-author-name">Michael Tayo</h3>
+        <p class="fm-author-title">Information Security Lead · Deputy CISO</p>
+      </div>
+      <p class="fm-author-bio">
+        A decade across cloud, application, and enterprise security.
+        Master's in Cybersecurity. I built CybersecurityOS because the
+        intelligence and frameworks I needed as a practitioner didn't exist
+        in one place — so I built the OS I wished I had.
+      </p>
+      <div class="fm-author-links">
+        <a href="/about/" class="fm-btn fm-btn--ghost" style="font-size:.78rem;">About Michael →</a>
+        <a href="/posts/" class="fm-btn fm-btn--ghost" style="font-size:.78rem;">Read the Posts →</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ FAQ ═══════════════════════════════════════════════════ -->
+  <section class="fm-faq-section" id="faq">
+    <div class="fm-section-label">// Common questions</div>
+    <h2 class="fm-section-title">FAQ</h2>
+    <div class="fm-faq-grid">
+      <div class="fm-faq-item">
+        <h4 class="fm-faq-q">What exactly is "vault access"?</h4>
+        <p class="fm-faq-a">The vault is a growing library of frameworks, templates, playbooks, and deep-dives accessible to OS Members. Think of it as the archive of everything published — plus exclusive content never posted publicly.</p>
+      </div>
+      <div class="fm-faq-item">
+        <h4 class="fm-faq-q">How does async Q&A work?</h4>
+        <p class="fm-faq-a">OS Members submit questions monthly. I respond in written form — could be a quick answer, a mini-framework, or a pointed recommendation. It's not live office hours; it's asynchronous and thoughtful.</p>
+      </div>
+      <div class="fm-faq-item">
+        <h4 class="fm-faq-q">Is the founding member rate really locked in?</h4>
+        <p class="fm-faq-a">Yes. If you join at $15/month today, that's your rate as long as you stay subscribed. Future tiers and expanded benefits will be priced higher for new members.</p>
+      </div>
+      <div class="fm-faq-item">
+        <h4 class="fm-faq-q">Can I cancel at any time?</h4>
+        <p class="fm-faq-a">Yes — no contracts, no lock-in. Cancel any time and you keep access through the end of your billing period.</p>
+      </div>
+      <div class="fm-faq-item">
+        <h4 class="fm-faq-q">What's the difference between annual and monthly?</h4>
+        <p class="fm-faq-a">Annual ($120/year) gives you two months free vs. monthly billing. Same access — you're just committing to the full year up front.</p>
+      </div>
+      <div class="fm-faq-item">
+        <h4 class="fm-faq-q">When is OS Pro launching?</h4>
+        <p class="fm-faq-a">No date set yet. OS Pro is being designed around consulting-adjacency — small cohort, meaningful access. OS Members will be first to know and first in line.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══ FINAL CTA ══════════════════════════════════════════════ -->
+  <section class="fm-final-cta" id="notify">
+    <div class="fm-final-grid" aria-hidden="true"></div>
+    <div class="fm-final-glow" aria-hidden="true"></div>
+    <div class="fm-final-content">
+      <p class="fm-eyebrow">// Ready to join?</p>
+      <h2 class="fm-final-title">Lock in your founding rate today.</h2>
+      <p class="fm-final-desc">Pricing increases as the vault grows. The rate you join at is the rate you keep.</p>
+      <div class="fm-final-actions">
+        <a href="https://store.cybersecurityos.net/l/os-member" class="fm-btn fm-btn--primary fm-btn--lg" target="_blank" rel="noopener">
+          Join OS Member — $15/mo →
+        </a>
+        <a href="https://store.cybersecurityos.net/l/os-member-annual" class="fm-btn fm-btn--ghost fm-btn--lg" target="_blank" rel="noopener">
+          Annual — $120/year
+        </a>
+      </div>
+      <p style="font-family:var(--os-font-mono);font-size:.68rem;color:var(--os-text-dim);margin-top:1.25rem;">
+        Or stay free → <a href="/posts/" style="color:var(--os-text-muted);text-decoration:none;border-bottom:1px solid var(--os-border);">Read the weekly OS</a>
+      </p>
+    </div>
+  </section>
+
+</div><!-- /fm-page -->
+
+<style>
+/* ═══════════════════════════════════════════════════════════════
+   Founding Member page styles
+   Extends the global design system (cybersecurityos.css)
+   ═══════════════════════════════════════════════════════════════ */
+
+.fm-page { background: var(--os-bg); }
+
+/* ── Hero ──────────────────────────────────────────────────── */
+.fm-hero {
+  position: relative;
+  padding: 6rem 2rem 5rem;
+  text-align: center;
+  overflow: hidden;
+}
+.fm-hero-grid {
+  position: absolute; inset: 0;
+  background-image:
+    linear-gradient(var(--os-border) 1px, transparent 1px),
+    linear-gradient(90deg, var(--os-border) 1px, transparent 1px);
+  background-size: 40px 40px;
+  opacity: 0.35;
+  pointer-events: none;
+}
+.fm-hero-glow {
+  position: absolute; inset: 0;
+  background: radial-gradient(ellipse 70% 55% at 50% 100%, var(--os-green-glow) 0%, transparent 70%);
+  pointer-events: none;
+}
+.fm-hero-content { position: relative; z-index: 1; max-width: 720px; margin: 0 auto; }
+
+.fm-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--os-font-mono);
+  font-size: 0.72rem;
+  color: var(--os-green);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin-bottom: 1.25rem;
+  background: rgba(0,255,136,0.07);
+  border: 1px solid var(--os-border-green);
+  padding: 0.3rem 0.8rem;
+  border-radius: 2px;
+}
+.fm-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--os-green);
+  box-shadow: 0 0 6px var(--os-green);
+  animation: pulse-dot 2s ease-in-out infinite;
+}
+
+.fm-title {
+  font-family: var(--os-font-heading) !important;
+  font-size: clamp(2.25rem, 6vw, 4rem);
+  font-weight: 900;
+  color: var(--os-text) !important;
+  line-height: 1.1;
+  margin: 0 auto 1.25rem;
+  letter-spacing: -0.01em;
+}
+.fm-title span { color: var(--os-green); }
+
+.fm-subtitle {
+  font-size: 1.05rem;
+  color: var(--os-text-muted);
+  max-width: 580px;
+  margin: 0 auto 2rem;
+  line-height: 1.75;
+}
+.fm-subtitle strong { color: var(--os-text); }
+
+.fm-hero-badges {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.fm-badge {
+  font-family: var(--os-font-mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.6rem;
+  border-radius: 2px;
+  border: 1px solid;
+}
+.fm-badge--green  { color: var(--os-green);  border-color: var(--os-border-green); background: var(--os-green-glow); }
+.fm-badge--purple { color: var(--os-medium); border-color: rgba(163,113,247,.3); background: rgba(163,113,247,.07); }
+.fm-badge--blue   { color: var(--os-low);   border-color: rgba(88,166,255,.3);  background: rgba(88,166,255,.07); }
+
+/* ── Section chrome ────────────────────────────────────────── */
+.fm-section-label {
+  font-family: var(--os-font-mono);
+  font-size: 0.68rem;
+  color: var(--os-green);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin-bottom: 0.5rem;
+}
+.fm-section-title {
+  font-family: var(--os-font-heading) !important;
+  font-size: clamp(1.3rem, 3vw, 1.75rem);
+  color: var(--os-text) !important;
+  margin: 0 0 2.5rem;
+  font-weight: 700;
+}
+
+/* ── Pricing section ───────────────────────────────────────── */
+.fm-pricing-section {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem;
+}
+
+.fm-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.fm-card {
+  background: var(--os-bg-surface);
+  border: 1px solid var(--os-border);
+  border-radius: var(--os-radius-md);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  overflow: visible;
+}
+.fm-card--featured {
+  border-color: var(--os-border-green);
+  box-shadow: 0 0 40px rgba(0,255,136,0.10), 0 0 1px var(--os-border-green);
+  transform: translateY(-4px);
+}
+.fm-card--future { opacity: 0.75; }
+
+.fm-popular-badge {
+  position: absolute;
+  top: -13px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--os-font-mono);
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  background: var(--os-green);
+  color: #080b10;
+  padding: 0.2rem 0.8rem;
+  border-radius: 2px;
+  white-space: nowrap;
+}
+.fm-coming-badge {
+  position: absolute;
+  top: -13px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--os-font-mono);
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  background: var(--os-bg-elevated);
+  color: var(--os-text-dim);
+  border: 1px solid var(--os-border-bright);
+  padding: 0.2rem 0.8rem;
+  border-radius: 2px;
+  white-space: nowrap;
+}
+
+.fm-card-header {
+  padding: 2rem 1.5rem 1.25rem;
+  border-bottom: 1px solid var(--os-border);
+}
+.fm-tier-badge {
+  font-family: var(--os-font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.5rem;
+  border-radius: 2px;
+  border: 1px solid;
+  display: inline-block;
+  margin-bottom: 0.75rem;
+}
+.fm-tier-badge--free   { color: var(--os-text-dim); border-color: var(--os-border); background: var(--os-bg-elevated); }
+.fm-tier-badge--member { color: var(--os-green);  border-color: var(--os-border-green); background: var(--os-green-glow); }
+.fm-tier-badge--pro    { color: var(--os-medium); border-color: rgba(163,113,247,.3); background: rgba(163,113,247,.07); }
+
+.fm-card-name {
+  font-family: var(--os-font-heading) !important;
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--os-text) !important;
+  margin: 0 0 1rem;
+}
+
+.fm-price {
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  margin-bottom: 0.25rem;
+}
+.fm-price-amount {
+  font-family: var(--os-font-heading);
+  font-size: 2.5rem;
+  font-weight: 900;
+  color: var(--os-text);
+  line-height: 1;
+}
+.fm-card--featured .fm-price-amount { color: var(--os-green); }
+.fm-price-cadence {
+  font-family: var(--os-font-mono);
+  font-size: 0.8rem;
+  color: var(--os-text-muted);
+}
+.fm-price-alt {
+  font-family: var(--os-font-mono);
+  font-size: 0.72rem;
+  color: var(--os-text-dim);
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.fm-save-badge {
+  background: rgba(0,255,136,0.12);
+  color: var(--os-green);
+  border: 1px solid var(--os-border-green);
+  font-size: 0.62rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 2px;
+  font-weight: 700;
+}
+.fm-card-desc {
+  font-size: 0.85rem;
+  color: var(--os-text-muted);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* Feature list */
+.fm-features {
+  list-style: none;
+  padding: 1.25rem 1.5rem;
+  margin: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+.fm-feature {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  color: var(--os-text);
+  line-height: 1.45;
+}
+.fm-feature--dim { color: var(--os-text-dim); }
+
+.fm-check {
+  font-family: var(--os-font-mono);
+  font-size: 0.8rem;
+  color: var(--os-info);
+  flex-shrink: 0;
+  margin-top: 0.05rem;
+  font-weight: 700;
+}
+.fm-check--green  { color: var(--os-green); }
+.fm-check--purple { color: var(--os-medium); }
+.fm-cross {
+  font-family: var(--os-font-mono);
+  font-size: 0.8rem;
+  color: var(--os-text-dim);
+  flex-shrink: 0;
+  margin-top: 0.05rem;
+}
+
+.fm-card-footer {
+  padding: 1.25rem 1.5rem 1.5rem;
+  border-top: 1px solid var(--os-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  align-items: stretch;
+}
+.fm-cta-note {
+  font-family: var(--os-font-mono);
+  font-size: 0.65rem;
+  color: var(--os-text-dim);
+  text-align: center;
+  margin: 0;
+}
+
+/* ── Buttons ───────────────────────────────────────────────── */
+.fm-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  font-family: var(--os-font-mono);
+  font-size: 0.82rem;
+  padding: 0.65rem 1.4rem;
+  border-radius: var(--os-radius);
+  text-decoration: none;
+  transition: all 0.2s;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  border: 1px solid transparent;
+  text-align: center;
+}
+.fm-btn--primary {
+  background: var(--os-green);
+  color: #080b10 !important;
+  font-weight: 700;
+  border-color: var(--os-green);
+}
+.fm-btn--primary:hover {
+  background: var(--os-green-deep);
+  box-shadow: 0 0 24px rgba(0,255,136,0.25);
+  color: #080b10 !important;
+}
+.fm-btn--ghost {
+  background: transparent;
+  color: var(--os-text-muted) !important;
+  border-color: var(--os-border-bright);
+}
+.fm-btn--ghost:hover {
+  color: var(--os-text) !important;
+  border-color: var(--os-border-green);
+  background: var(--os-green-glow);
+}
+.fm-btn--disabled {
+  pointer-events: none;
+  opacity: 0.45;
+}
+.fm-btn--lg { padding: 0.85rem 2rem; font-size: 0.9rem; }
+
+/* ── Founding Member callout ────────────────────────────────── */
+.fm-callout {
+  max-width: 860px;
+  margin: 0 auto 1rem;
+  padding: 0 1.5rem;
+}
+.fm-callout-inner {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.25rem;
+  background: var(--os-bg-surface);
+  border: 1px solid var(--os-border-green);
+  border-radius: var(--os-radius-md);
+  padding: 1.5rem;
+}
+.fm-callout-icon {
+  font-size: 1.5rem;
+  flex-shrink: 0;
+  margin-top: 0.15rem;
+}
+.fm-callout-title {
+  font-family: var(--os-font-heading) !important;
+  font-size: 1rem;
+  color: var(--os-text) !important;
+  margin: 0 0 0.5rem;
+}
+.fm-callout-body {
+  font-size: 0.875rem;
+  color: var(--os-text-muted);
+  line-height: 1.7;
+  margin: 0;
+}
+
+/* ── Vault section ──────────────────────────────────────────── */
+.fm-vault-section {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem;
+  border-top: 1px solid var(--os-border);
+}
+.fm-vault-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+.fm-vault-item {
+  background: var(--os-bg-surface);
+  border: 1px solid var(--os-border);
+  border-radius: var(--os-radius-md);
+  padding: 1.5rem;
+  transition: border-color 0.2s;
+}
+.fm-vault-item:hover { border-color: var(--os-border-green); }
+.fm-vault-icon { font-size: 1.5rem; display: block; margin-bottom: 0.75rem; }
+.fm-vault-item h4 {
+  font-family: var(--os-font-heading) !important;
+  font-size: 0.9rem;
+  color: var(--os-text) !important;
+  margin: 0 0 0.5rem;
+}
+.fm-vault-item p {
+  font-size: 0.82rem;
+  color: var(--os-text-muted);
+  line-height: 1.65;
+  margin: 0;
+}
+
+/* ── Author section ─────────────────────────────────────────── */
+.fm-author {
+  background: var(--os-bg-surface);
+  border-top: 1px solid var(--os-border);
+  border-bottom: 1px solid var(--os-border);
+  padding: 4rem 1.5rem;
+}
+.fm-author-inner {
+  max-width: 760px;
+  margin: 0 auto;
+}
+.fm-author-label {
+  font-family: var(--os-font-mono);
+  font-size: 0.68rem;
+  color: var(--os-green);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  margin: 0 0 0.4rem;
+}
+.fm-author-name {
+  font-family: var(--os-font-heading) !important;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--os-text) !important;
+  margin: 0 0 0.2rem;
+}
+.fm-author-title {
+  font-family: var(--os-font-mono);
+  font-size: 0.75rem;
+  color: var(--os-text-dim);
+  margin: 0 0 1.25rem;
+}
+.fm-author-bio {
+  font-size: 0.95rem;
+  color: var(--os-text-muted);
+  line-height: 1.75;
+  margin: 0 0 1.5rem;
+}
+.fm-author-links { display: flex; gap: 0.75rem; flex-wrap: wrap; }
+
+/* ── FAQ ────────────────────────────────────────────────────── */
+.fm-faq-section {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem;
+}
+.fm-faq-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.25rem;
+}
+.fm-faq-item {
+  background: var(--os-bg-surface);
+  border: 1px solid var(--os-border);
+  border-radius: var(--os-radius-md);
+  padding: 1.5rem;
+}
+.fm-faq-q {
+  font-family: var(--os-font-heading) !important;
+  font-size: 0.9rem;
+  color: var(--os-text) !important;
+  margin: 0 0 0.6rem;
+}
+.fm-faq-a {
+  font-size: 0.84rem;
+  color: var(--os-text-muted);
+  line-height: 1.7;
+  margin: 0;
+}
+
+/* ── Final CTA ──────────────────────────────────────────────── */
+.fm-final-cta {
+  position: relative;
+  padding: 6rem 2rem;
+  text-align: center;
+  overflow: hidden;
+  background: var(--os-bg-surface);
+  border-top: 1px solid var(--os-border);
+}
+.fm-final-grid {
+  position: absolute; inset: 0;
+  background-image:
+    linear-gradient(var(--os-border) 1px, transparent 1px),
+    linear-gradient(90deg, var(--os-border) 1px, transparent 1px);
+  background-size: 32px 32px;
+  opacity: 0.25;
+  pointer-events: none;
+}
+.fm-final-glow {
+  position: absolute; inset: 0;
+  background: radial-gradient(ellipse 50% 60% at 50% 0%, var(--os-green-glow) 0%, transparent 70%);
+  pointer-events: none;
+}
+.fm-final-content { position: relative; z-index: 1; max-width: 600px; margin: 0 auto; }
+.fm-final-title {
+  font-family: var(--os-font-heading) !important;
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  font-weight: 900;
+  color: var(--os-text) !important;
+  margin: 0.75rem auto 1rem;
+}
+.fm-final-desc {
+  font-size: 0.95rem;
+  color: var(--os-text-muted);
+  margin: 0 auto 2.25rem;
+  max-width: 440px;
+}
+.fm-final-actions { display: flex; justify-content: center; gap: 0.75rem; flex-wrap: wrap; }
+
+/* ── Responsive ─────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .fm-cards { grid-template-columns: 1fr; }
+  .fm-card--featured { transform: none; }
+  .fm-vault-grid { grid-template-columns: repeat(2, 1fr); }
+  .fm-faq-grid { grid-template-columns: 1fr; }
+}
+@media (max-width: 600px) {
+  .fm-vault-grid { grid-template-columns: 1fr; }
+  .fm-hero { padding: 4rem 1rem 3.5rem; }
+  .fm-final-cta { padding: 4rem 1rem; }
+  .fm-author, .fm-vault-section, .fm-faq-section, .fm-pricing-section { padding-left: 1rem; padding-right: 1rem; }
+}
+</style>
+{{ end }}


### PR DESCRIPTION
## Summary

Two changes in one branch:

### 1. Futuristic dark theme redesign
Unified the SPECTRA design language (green `#00ff88` / dark `#0d1117`) across the full site — previously only SPECTRA pages had the cyber aesthetic while the blog used Ananke's default light theme.

- **Design system** (`assets/css/cybersecurityos.css`) — CSS custom properties for color, type, spacing, and severity scales; Orbitron + Share Tech Mono + Inter fonts; global dark base; green reading progress bar
- **Navigation** — sticky glassmorphism nav, `~/CYBERSECURITYOS` brand with blinking cursor, monospace links, homepage hero with stat counters and CTA buttons
- **Post cards** — dark card grid, green scan-line top border on hover, lift + glow animation
- **Single post** — 760px dark reading column, terminal blockquotes, dark code blocks, dark-striped tables
- **Tag badges** — CVE-severity color system (green/amber/purple/red/blue)
- **Footer** — status bar with animated live dot + `[CybersecurityOS] v2.0 · security-focused · AI-powered`

### 2. Founding Member pricing page (`/founding-member/`)

Three membership tiers:

| Tier | Price | Key benefit |
|---|---|---|
| **Reader** | Free | Weekly posts, release notes, public content |
| **OS Member** | $15/mo or $120/yr | + Vault, monthly deep-dive, async Q&A |
| **OS Pro** | $49/mo *(coming soon)* | + Private Slack/Discord, async strategy review |

Page sections: hero → pricing cards → founding member callout → vault content grid (6 categories) → author bio → FAQ (6 Q&As) → final CTA. "Membership" added to site nav.

## Test plan
- [ ] Hugo build: 0 errors, 298 pages ✅
- [ ] Verify `/founding-member/` renders with all three cards
- [ ] Verify nav shows "Membership" link
- [ ] Check dark theme on homepage, a post, and the list page
- [ ] Check mobile nav toggle works

🤖 Generated with [Claude Code](https://claude.com/claude-code)