### PR TITLE
fix: Membership nav links directly to Gumroad

### DIFF
--- a/content/founding-member.md
+++ b/content/founding-member.md
@@ -2,6 +2,6 @@
 title: "Founding Member"
 description: "Join CybersecurityOS as a Founding Member. Three tiers built for security engineers, leaders, and career climbers — from free weekly intelligence to hands-on async strategy."
 type: "founding-member"
-draft: false
+draft: true
 slug: "founding-member"
 ---

--- a/hugo.toml
+++ b/hugo.toml
@@ -60,7 +60,7 @@ googleAnalytics = "YOUR_TRACKING_ID"  # Replace with your Google Analytics track
 
 [[menu.main]]
   name = "Membership"
-  url = "/founding-member/"
+  url = "https://cybersecurityos.gumroad.com/l/os-member"
   weight = 6
 
 # Enable the sitemap


### PR DESCRIPTION
Simple: nav "Membership" now points directly to Gumroad, custom page drafted out.

- `hugo.toml`: Membership URL → `https://cybersecurityos.gumroad.com/l/os-member`  
- `content/founding-member.md`: `draft: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)