### PR TITLE
fix: remove duplicate Store nav link, keep green CTA button

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -48,10 +48,6 @@ googleAnalytics = "YOUR_TRACKING_ID"  # Replace with your Google Analytics track
   url = "/docs/"
   weight = 3
 
-[[menu.main]]
-  name = "Store"
-  url = "https://store.cybersecurityos.net/"
-  weight = 4
 
  [[menu.main]]
   name = "Contact"

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -17,6 +17,11 @@
         </a>
       </li>
       {{ end }}
+      <li>
+        <a href="https://store.cybersecurityos.net/" class="os-nav-cta" target="_blank" rel="noopener">
+          Store ↗
+        </a>
+      </li>
     </ul>
 
     <!-- Mobile toggle -->

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -17,11 +17,6 @@
         </a>
       </li>
       {{ end }}
-      <li>
-        <a href="https://store.cybersecurityos.net/" class="os-nav-cta" target="_blank" rel="noopener">
-          Store ↗
-        </a>
-      </li>
     </ul>
 
     <!-- Mobile toggle -->


### PR DESCRIPTION
## What changed

- Removed `Store` from `hugo.toml` menu config — it was duplicating the green button
- Restored the green `Store ↗` CTA button in `site-header.html` — this is the right treatment
- `hugo.toml`: Membership nav → `https://cybersecurityos.gumroad.com/l/os-member`
- `content/founding-member.md`: `draft: true` (custom page no longer needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)