### PR TITLE
feat: place all three Kit forms at optimal positions

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -62,6 +62,8 @@
       {{ template "_internal/google_analytics.html" . }}
     {{ end }}
 	{{ block "head" . }}{{ partial "head-additions.html" . }}{{ end }}
+    <!-- Kit: sticky banner (early load so it renders above viewport content) -->
+    <script async data-uid="1201517798" src="https://theghettoflower.kit.com/1201517798/index.js"></script>
   </head>
 
   <body class="ma0{{ with getenv "HUGO_ENV" }} {{ . }}{{ end }}">
@@ -92,5 +94,7 @@
         toggle.addEventListener('click', function() { links.classList.toggle('open'); });
       })();
     </script>
+    <!-- Kit: popup (late load — fires after page is interactive) -->
+    <script async data-uid="216ee976c6" src="https://theghettoflower.kit.com/216ee976c6/index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Three Kit forms, each placed at the position that matches how Kit renders that form type.

| Form | UID | Placement | Why |
|---|---|---|---|
| Banner | `1201517798` | `<head>` in `baseof.html` | Kit sticky bars need early load to render above the viewport before content paints |
| Popup | `216ee976c6` | End of `<body>` in `baseof.html` | Fires after page is interactive — better UX, doesn't compete with initial render |
| Inline | `63abb6cee3` | `site-footer.html` | Already in place; renders exactly inside the footer subscribe section |

No old scripts were removed (footer was already clean). No duplication across any page.

Hugo build: 307 pages, 0 errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)