### PR TITLE
fix: publish founding-member page

### DIFF
--- a/content/founding-member.md
+++ b/content/founding-member.md
@@ -2,6 +2,6 @@
 title: "Founding Member"
 description: "Join CybersecurityOS as a Founding Member. Three tiers built for security engineers, leaders, and career climbers — from free weekly intelligence to hands-on async strategy."
 type: "founding-member"
-draft: true
+draft: false
 slug: "founding-member"
 ---


### PR DESCRIPTION
## Problem

`content/founding-member.md` had `draft: true` — Netlify's production build (`hugo --minify`) skips drafts, so the page existed locally but not on the live site.

## Fix

`draft: false` — page now builds in production at `/founding-member/`.

Hugo build: 308 pages ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)