### PR TITLE
feat: hugo site performance, accessibility, and CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,29 +14,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install dependencies
         run: npm ci
       - name: Run markdownlint
         run: npm run lint:md
-        # Allow markdown lint failures without failing the entire workflow
-        continue-on-error: true
 
   hugo-build:
     name: Hugo Build
     runs-on: ubuntu-latest
-    needs: markdown-lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.160.1'
           extended: true
       - name: Build site with Hugo
-        run: hugo --minify
+        env:
+          HUGO_ENV: production
+        run: hugo --minify --gc

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.134.2
+      HUGO_VERSION: 0.160.1
     steps:
       - name: Install Hugo CLI
         run: |
@@ -59,6 +59,7 @@ jobs:
         env:
           HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
           HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
           TZ: America/Los_Angeles
         run: |
           hugo \

--- a/assets/css/cybersecurityos.css
+++ b/assets/css/cybersecurityos.css
@@ -1158,3 +1158,36 @@ article.pa3, article.pa4-ns { background: transparent !important; }
   .fm-problem, .fm-solution, .fm-deliverables, .fm-for-section,
   .fm-urgency, .fm-pricing-simple { padding-left: 1rem; padding-right: 1rem; }
 }
+
+/* ─── Skip Navigation Link ──────────────────────────────────── */
+.os-skip-link {
+  position: absolute;
+  top: -100%;
+  left: 1rem;
+  z-index: 9999;
+  padding: 0.5rem 1rem;
+  background: var(--os-bg-elevated);
+  color: var(--os-green);
+  font-family: var(--os-font-mono);
+  font-size: 0.875rem;
+  border: 1px solid var(--os-border-green);
+  border-radius: var(--os-radius);
+  text-decoration: none;
+  transition: top 0.1s;
+}
+.os-skip-link:focus {
+  top: 1rem;
+}
+
+/* ─── Article featured image ────────────────────────────────── */
+.os-article-image {
+  margin: 1.5rem 0 2rem;
+  border-radius: var(--os-radius-md);
+  overflow: hidden;
+  border: 1px solid var(--os-border);
+}
+.os-article-feat-img {
+  width: 100%;
+  height: auto;
+  display: block;
+}

--- a/hugo.toml
+++ b/hugo.toml
@@ -59,9 +59,22 @@ googleAnalytics = "YOUR_TRACKING_ID"  # Replace with your Google Analytics track
   url = "https://cybersecurityos.gumroad.com/l/os-member"
   weight = 6
 
-# Enable the sitemap
-[params.sitemap]
-  sitemap = true
+# Image processing pipeline (WebP conversion, quality, EXIF stripping)
+[imaging]
+  quality = 85
+  resampleFilter = "Lanczos"
+
+[imaging.exif]
+  includeFields = ""
+  excludeFields = ".*"
+  disableDate = true
+  disableLatLong = true
+
+# Sitemap
+[sitemap]
+  changefreq = "weekly"
+  filename   = "sitemap.xml"
+  priority   = 0.5
 
 [services]
   [services.disqus]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,7 +14,7 @@
     {{ if and $production $public }}
       <meta name="robots" content="index, follow">
     {{ else }}
-      <meta name="robots" content="index, follow">
+      <meta name="robots" content="noindex, nofollow">
     {{ end }}
     {{ with .Params.author | default .Site.Params.author }}
       <meta name="author" content = "
@@ -67,10 +67,11 @@
   </head>
 
   <body class="ma0{{ with getenv "HUGO_ENV" }} {{ . }}{{ end }}">
+    <a class="os-skip-link" href="#main-content">Skip to main content</a>
     <div id="os-progress"></div>
 
     {{ block "header" . }}{{ partial "site-header.html" .}}{{ end }}
-    <main class="pb7" role="main">
+    <main id="main-content" class="pb7" role="main">
       {{ block "main" . }}{{ end }}
     </main>
     {{ block "footer" . }}{{ partialCached "site-footer.html" . }}{{ end }}
@@ -91,7 +92,10 @@
         var toggle = document.querySelector('.os-nav-toggle');
         var links  = document.querySelector('.os-nav-links');
         if (!toggle || !links) return;
-        toggle.addEventListener('click', function() { links.classList.toggle('open'); });
+        toggle.addEventListener('click', function() {
+          var isOpen = links.classList.toggle('open');
+          toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        });
       })();
     </script>
     <!-- Kit: popup (late load — fires after page is interactive) -->

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,6 +4,8 @@
 {{ end }}
 
 {{ define "main" }}
+  {{ $featuredURL := partial "func/GetFeaturedImage.html" . }}
+  {{ $featuredRes := partial "func/GetFeaturedImageObject.html" . }}
   <div class="os-article-wrap">
 
     <!-- Article header -->
@@ -45,6 +47,17 @@
       <!-- Tags -->
       {{ partial "tags.html" . }}
     </header>
+
+    <!-- Featured image -->
+    {{ if or $featuredRes $featuredURL }}
+    <div class="os-article-image">
+      {{ partial "func/ResponsiveImage.html" (dict
+          "resource" $featuredRes
+          "url"      $featuredURL
+          "alt"      .Title
+          "class"    "os-article-feat-img") }}
+    </div>
+    {{ end }}
 
     <!-- Article body -->
     <div class="os-prose">

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -1,10 +1,15 @@
 {{/* Post card — used in list.html and index.html card grid */}}
-{{ $featured := partial "func/GetFeaturedImage.html" . }}
+{{ $featuredURL := partial "func/GetFeaturedImage.html" . }}
+{{ $featuredRes := partial "func/GetFeaturedImageObject.html" . }}
 
 <article class="os-card">
-  {{ if $featured }}
+  {{ if or $featuredRes $featuredURL }}
     <a href="{{ .RelPermalink }}" tabindex="-1" aria-hidden="true">
-      <img class="os-card-img" src="{{ $featured }}" alt="{{ .Title }}" loading="lazy">
+      {{ partial "func/ResponsiveImage.html" (dict
+          "resource" $featuredRes
+          "url"      $featuredURL
+          "alt"      .Title
+          "class"    "os-card-img") }}
     </a>
   {{ end }}
 

--- a/layouts/partials/func/GetFeaturedImageObject.html
+++ b/layouts/partials/func/GetFeaturedImageObject.html
@@ -1,0 +1,22 @@
+{{/*
+  GetFeaturedImageObject
+  Returns the featured image as a Hugo image resource when it is a page-bundle
+  resource (enables Hugo's image-processing pipeline — resize, WebP, srcset).
+  Falls back to an empty string for static-dir images, which are handled by
+  the original GetFeaturedImage partial as plain URLs.
+
+  @return  Hugo image resource, or empty string.
+*/}}
+{{ $resource := "" }}
+{{ with .Params.featured_image }}
+  {{ with $.Resources.GetMatch . }}
+    {{ $resource = . }}
+  {{ end }}
+{{ else }}
+  {{ with .Resources.ByType "image" }}
+    {{ with .GetMatch "**{feature,cover}*" }}
+      {{ $resource = . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ return $resource }}

--- a/layouts/partials/func/ResponsiveImage.html
+++ b/layouts/partials/func/ResponsiveImage.html
@@ -1,0 +1,44 @@
+{{/*
+  ResponsiveImage
+  Renders an optimised image element. When passed a Hugo image resource it
+  produces a <picture> with WebP + srcset; otherwise a plain lazy-loaded <img>.
+
+  Call with a dict:
+    resource — Hugo image resource (from GetFeaturedImageObject); may be empty
+    url      — Fallback absolute URL string (from GetFeaturedImage)
+    alt      — Alt text string
+    class    — CSS class string
+*/}}
+{{ $resource := .resource }}
+{{ $url      := .url }}
+{{ $alt      := .alt   | default "" }}
+{{ $class    := .class | default "" }}
+
+{{ if $resource }}
+  {{/* Page-bundle image: process into WebP + JPEG at two breakpoints */}}
+  {{ $webp800 := $resource.Resize "800x webp q85" }}
+  {{ $webp400 := $resource.Resize "400x webp q85" }}
+  {{ $jpg800  := $resource.Resize "800x q85" }}
+  <picture>
+    <source
+      type="image/webp"
+      srcset="{{ $webp400.RelPermalink }} 400w, {{ $webp800.RelPermalink }} 800w"
+      sizes="(max-width: 600px) 400px, 800px">
+    <img
+      src="{{ $jpg800.RelPermalink }}"
+      width="{{ $jpg800.Width }}"
+      height="{{ $jpg800.Height }}"
+      alt="{{ $alt }}"
+      loading="lazy"
+      decoding="async"
+      {{ with $class }}class="{{ . }}"{{ end }}>
+  </picture>
+{{ else if $url }}
+  {{/* Static-dir image: serve as-is with lazy loading */}}
+  <img
+    src="{{ $url }}"
+    alt="{{ $alt }}"
+    loading="lazy"
+    decoding="async"
+    {{ with $class }}class="{{ . }}"{{ end }}>
+{{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "hugo --minify"
+  command = "hugo --minify --gc"
   publish = "public"
 
 [build.environment]


### PR DESCRIPTION
Performance:
- Add Hugo image processing pipeline (WebP + srcset) via new
  ResponsiveImage and GetFeaturedImageObject partials; page-bundle
  images are auto-converted to WebP at 400w/800w with JPEG fallback
- Add decoding="async" alongside existing loading="lazy" on all
  card and article featured images
- Add [imaging] config (q85, Lanczos, EXIF strip) to hugo.toml
- Fix sitemap config from [params.sitemap] to top-level [sitemap]
- Add --gc flag to netlify.toml build command

Accessibility:
- Add skip-to-main-content link with matching #main-content anchor
- Fix mobile nav aria-expanded: JS now toggles true/false on click
- Fix robots meta: non-production builds now emit noindex,nofollow

CI/CD:
- Align Hugo version across all environments: 0.134.2 → 0.160.1
- Add HUGO_ENV=production to deploy.yml so GA and robots tags fire
- Remove continue-on-error from markdown-lint (failures now block PRs)
- Run markdown-lint and hugo-build in parallel (faster CI)
- Pin CI to hugo 0.160.1 and Node 20; add submodule checkout and --gc
- Update actions/checkout and actions/setup-node to v4

https://claude.ai/code/session_01FVnqM8uJD6LBDEsiS8nvEP