### PR TITLE
fix: address post-merge code review findings

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
   "default": true,
-  "MD013": false
+  "MD013": false,
+  "MD033": false
 }

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -48,14 +48,15 @@
       {{ partial "tags.html" . }}
     </header>
 
-    <!-- Featured image -->
+    <!-- Featured image (LCP element — load eagerly) -->
     {{ if or $featuredRes $featuredURL }}
     <div class="os-article-image">
       {{ partial "func/ResponsiveImage.html" (dict
           "resource" $featuredRes
           "url"      $featuredURL
           "alt"      .Title
-          "class"    "os-article-feat-img") }}
+          "class"    "os-article-feat-img"
+          "lazy"     false) }}
     </div>
     {{ end }}
 

--- a/layouts/_default/summary-with-image.html
+++ b/layouts/_default/summary-with-image.html
@@ -1,16 +1,20 @@
-{{ $featured_image := partial "func/GetFeaturedImage.html" . }}
+{{ $featuredURL := partial "func/GetFeaturedImage.html" . }}
+{{ $featuredRes := partial "func/GetFeaturedImageObject.html" . }}
 <article class="bb b--black-10">
   <div class="db pv4 ph3 ph0-l no-underline dark-gray">
     <div class="flex flex-column flex-row-ns">
-      {{ if $featured_image }}
-          {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
+      {{ if or $featuredRes $featuredURL }}
         <div class="{{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl3-ns" "pr3-ns" }} mb4 mb0-ns w-100 w-40-ns">
           <a href="{{.RelPermalink}}" class="db grow">
-            <img src="{{ $featured_image }}" class="img" alt="image from {{ .Title }}">
+            {{ partial "func/ResponsiveImage.html" (dict
+                "resource" $featuredRes
+                "url"      $featuredURL
+                "alt"      .Title
+                "class"    "img") }}
           </a>
         </div>
       {{ end }}
-      <div class="blah w-100{{ if $featured_image }} w-60-ns {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pr3-ns" "pl3-ns" }}{{ end }}">
+      <div class="blah w-100{{ if or $featuredRes $featuredURL }} w-60-ns {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pr3-ns" "pl3-ns" }}{{ end }}">
         <h1 class="f3 fw1 athelas mt0 lh-title">
           <a href="{{.RelPermalink}}" class="color-inherit dim link">
             {{ .Title }}

--- a/layouts/partials/func/GetFeaturedImageObject.html
+++ b/layouts/partials/func/GetFeaturedImageObject.html
@@ -5,11 +5,17 @@
   Falls back to an empty string for static-dir images, which are handled by
   the original GetFeaturedImage partial as plain URLs.
 
+  For pages that set featured_image as an absolute site path
+  (e.g. /posts/section/images/cover.jpg), the filename is extracted with
+  path.Base so Resources.GetMatch can locate it within the page bundle.
+
   @return  Hugo image resource, or empty string.
 */}}
 {{ $resource := "" }}
 {{ with .Params.featured_image }}
-  {{ with $.Resources.GetMatch . }}
+  {{/* Extract just the filename so absolute paths resolve inside the bundle */}}
+  {{ $filename := path.Base . }}
+  {{ with $.Resources.GetMatch (printf "**/%s" $filename) }}
     {{ $resource = . }}
   {{ end }}
 {{ else }}

--- a/layouts/partials/func/ResponsiveImage.html
+++ b/layouts/partials/func/ResponsiveImage.html
@@ -1,18 +1,22 @@
 {{/*
   ResponsiveImage
   Renders an optimised image element. When passed a Hugo image resource it
-  produces a <picture> with WebP + srcset; otherwise a plain lazy-loaded <img>.
+  produces a <picture> with WebP + srcset; otherwise a plain <img>.
 
   Call with a dict:
     resource — Hugo image resource (from GetFeaturedImageObject); may be empty
     url      — Fallback absolute URL string (from GetFeaturedImage)
     alt      — Alt text string
     class    — CSS class string
+    lazy     — Boolean: true (default) adds loading="lazy"; false emits
+               loading="eager" for above-the-fold / LCP images
 */}}
 {{ $resource := .resource }}
 {{ $url      := .url }}
 {{ $alt      := .alt   | default "" }}
 {{ $class    := .class | default "" }}
+{{ $lazy     := .lazy  | default true }}
+{{ $loading  := cond $lazy "lazy" "eager" }}
 
 {{ if $resource }}
   {{/* Page-bundle image: process into WebP + JPEG at two breakpoints */}}
@@ -29,16 +33,16 @@
       width="{{ $jpg800.Width }}"
       height="{{ $jpg800.Height }}"
       alt="{{ $alt }}"
-      loading="lazy"
+      loading="{{ $loading }}"
       decoding="async"
       {{ with $class }}class="{{ . }}"{{ end }}>
   </picture>
 {{ else if $url }}
-  {{/* Static-dir image: serve as-is with lazy loading */}}
+  {{/* Static-dir image: serve as-is */}}
   <img
     src="{{ $url }}"
     alt="{{ $alt }}"
-    loading="lazy"
+    loading="{{ $loading }}"
     decoding="async"
     {{ with $class }}class="{{ . }}"{{ end }}>
 {{ end }}


### PR DESCRIPTION
## Summary

- **LCP regression fix** — `ResponsiveImage` partial now accepts a `lazy` boolean param (defaults `true`). `single.html` passes `lazy: false` so the article featured image loads eagerly instead of being deferred — fixing the Core Web Vitals LCP regression introduced in PR #131
- **`GetFeaturedImageObject` path fix** — uses `path.Base` to strip the absolute path prefix from `featured_image` values (e.g. `/posts/section/images/cover.jpg` → `cover.jpg`) before calling `Resources.GetMatch`, so the WebP pipeline will work correctly when posts are migrated to page bundles
- **`summary-with-image.html` gap closed** — was still using a plain `<img>` via the old `GetFeaturedImage` partial, bypassing all image optimisation added in #131; now uses `GetFeaturedImageObject` + `ResponsiveImage` like the other card templates
- **CI hard-fail fix** — added `"MD033": false` to `.markdownlint.json` to allow inline HTML in posts; several existing posts use inline `<img>` tags that would have broken the now-blocking markdown-lint CI job

## Test plan

- [ ] Verify article pages render the featured image with `loading="eager"` (not `loading="lazy"`) in the rendered HTML
- [ ] Verify post cards on list/index pages still render images with `loading="lazy"`
- [ ] Verify `summary-with-image.html` cards render images (check homepage or any section using that layout)
- [ ] Push a test post containing an inline `<img>` tag and confirm CI passes markdown-lint
- [ ] Confirm Hugo build completes without errors (`hugo --minify --gc`)

https://claude.ai/code/session_01FVnqM8uJD6LBDEsiS8nvEP

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVnqM8uJD6LBDEsiS8nvEP)_