### PR TITLE
fix: post-merge housekeeping — Node.js 20 deprecation, lock file, config cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Install dependencies
         run: npm ci
       - name: Run markdownlint
@@ -27,16 +27,18 @@ jobs:
   hugo-build:
     name: Hugo Build
     runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.160.1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
-        with:
-          hugo-version: '0.160.1'
-          extended: true
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb \
+            https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
       - name: Build site with Hugo
         env:
           HUGO_ENV: production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,12 +49,9 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
       - name: Install Node.js dependencies
-        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+        run: npm ci
       - name: Check code style with Prettier
-        # Allow non-zero exit so CI can continue even if formatting issues exist
-        continue-on-error: true
-        run: |
-          npx prettier --check .
+        run: npm run lint:format
       - name: Build with Hugo
         env:
           HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache

--- a/hugo.toml
+++ b/hugo.toml
@@ -6,8 +6,10 @@ theme = "ananke"
 # SEO Metadata
 description = "A comprehensive resource for cybersecurity professionals, providing insights, tools, and services."
 keywords = "cybersecurity, security tools, professional development, best practices"
-author = "Your Name"  # Replace with your actual name or organization
-googleAnalytics = "YOUR_TRACKING_ID"  # Replace with your Google Analytics tracking ID
+author = "Michael Tayo"
+# To enable Google Analytics add your tracking ID:
+# [services.googleAnalytics]
+#   id = "G-XXXXXXXXXX"
 
 # Permalinks
 [permalinks]
@@ -24,7 +26,7 @@ googleAnalytics = "YOUR_TRACKING_ID"  # Replace with your Google Analytics track
   favicon = "images/c-os-l.svg"   # Path to your favicon
   site_logo = "images/c-os.svg" 
   showSocialLinks = true        # Show social links in the footer (if supported by the theme)
-  paginate = 10                  # this is set low for demonstrating with dummy content. Set to a higher number
+  paginate = 20
   rss = "index.xml" #rss
   show_reading_time = true
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,107 @@
     "": {
       "devDependencies": {
         "markdownlint-cli": "^0.48.0",
+        "pagefind": "^1.3.0",
         "prettier": "^3.3.3"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
@@ -1015,6 +1114,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",


### PR DESCRIPTION
## What & Why

Four items left over after PR #133 merged.

### 1. Node.js 20 deprecation (deadline: June 16, 2026)

CI was warned: `peaceiris/actions-hugo@v2` and `actions/setup-node@v4` (node 20) will be **forced to Node.js 24** in 11 days, which will break CI.

- `ci.yml`: removed `peaceiris/actions-hugo@v2` entirely — replaced with a direct `wget`/`dpkg` Hugo install, which is the same approach `deploy.yml` already uses and has zero Node.js runtime dependency
- `ci.yml`: `actions/setup-node` bumped from `node-version: '20'` → `'22'` (current LTS)

### 2. Missing `package-lock.json`

`deploy.yml` had `[[ -f package-lock.json ]] && npm ci || true` — because no lock file was committed, `npm ci` silently skipped and `pagefind` was downloaded fresh on every deploy via `npx`. Now:
- `package-lock.json` committed (generated from current `package.json`)
- `deploy.yml` simplified to `npm ci` (no guard needed)
- `pagefind` and other devDeps are now installed at a pinned version

### 3. `deploy.yml` Prettier check

Previously `npx prettier --check .` with `continue-on-error: true` — it was always erroring on Hugo template files even before we added `.prettierignore`. Now uses `npm run lint:format` which is scoped to `content/**/*.md` and `assets/**/*.css`, so `continue-on-error` can be dropped.

### 4. `hugo.toml` config placeholders

- `author = "Your Name"` → `"Michael Tayo"`
- Removed `googleAnalytics = "YOUR_TRACKING_ID"` (unused placeholder); replaced with a commented example using the modern `[services.googleAnalytics] id = "G-..."` format (Hugo 0.120+)
- `paginate = 10` → `20` (the comment in the file itself said "set low for dummy content, set higher")

## Test plan

- [ ] CI passes (Hugo build + lychee link check)
- [ ] Hugo build step installs Hugo 0.160.1 via wget without peaceiris action
- [ ] Node.js 20 deprecation warning gone from CI logs
- [ ] Deploy runs `npm ci` and installs pagefind from lock file
- [ ] Prettier check passes scoped to MD + CSS

https://claude.ai/code/session_014trpiNKPPXHDsm4VXZesSA

---
_Generated by [Claude Code](https://claude.ai/code/session_014trpiNKPPXHDsm4VXZesSA)_