### PR TITLE
Add post: Claude Fable 5 & Mythos 5 cybersecurity analysis

### DIFF
--- a/content/posts/os-weekly/claude-fable-5-mythos-5.md
+++ b/content/posts/os-weekly/claude-fable-5-mythos-5.md
@@ -1,0 +1,125 @@
+---
+title: "The Frontier, Split in Two: What Claude Fable 5 and Mythos 5 Mean for Cybersecurity"
+date: 2026-06-10
+draft: false
+tags: ["CybersecurityOS", "Cybersecurity", "Artificial Intelligence", "Claude", "Anthropic", "AI Safety", "Cyber Defense"]
+categories: ["AI & Security"]
+description: "Anthropic just released Claude Fable 5 — its most capable public model ever — alongside Claude Mythos 5, the most powerful cybersecurity model in the world. Here's what the split-frontier strategy means for defenders, leaders, and aspiring professionals."
+slug: "claude-fable-5-mythos-5-cybersecurity"
+show_reading_time: true
+---
+
+On June 9, 2026, Anthropic did something it had never done before: it shipped a **Mythos-class model to the public**. [Claude Fable 5 and Claude Mythos 5](https://www.anthropic.com/news/claude-fable-5-mythos-5) are the same underlying model wearing two very different sets of guardrails — and that single design decision says a lot about where frontier AI and cybersecurity are headed.
+
+For security leaders, defenders, and anyone building a career in this field, this isn't just another model release. It's a preview of how the most capable systems will be governed when their cyber capabilities outrun the safety norms we've relied on.
+
+> 💡 **Want to lead with clarity in the AI era?**
+> If you're aiming to lead a security team, break into cybersecurity, or operate with greater speed and confidence, this is the toolkit you've been missing:
+> 🔗 [Cybersecurity Leadership OS: Battle-Tested Mental Models for Clarity, Speed & Command](https://store.cybersecurityos.net/l/cybersecurity-leadership-os)
+
+---
+
+## One Model, Two Faces
+
+The headline of this release is a *governance* idea, not just a capability one.
+
+- **Claude Fable 5** is the public-facing release for enterprise customers and paid subscribers. It's state-of-the-art on nearly every tested benchmark, but ships with production safeguards that block high-risk requests.
+- **Claude Mythos 5** is the *same base model* with safeguards lifted in sensitive domains. It carries the strongest cybersecurity capabilities of any model in the world, and is being released through restricted channels only.
+
+Anthropic's framing is that the frontier has been deliberately **split in two**: maximum capability for the public, *minus* the dangerous edges — and the full, unrestricted edge reserved for vetted defenders.
+
+---
+
+## What Fable 5 Can Actually Do
+
+Fable 5 is, by the numbers, Anthropic's most capable generally available model to date. A few benchmark highlights making the rounds:
+
+- **80.3%** on SWE-Bench Pro — well ahead of Claude Opus 4.8 (69.2%) and GPT-5.5 (58.6%).
+- The first model to exceed **90%** on Hex's analytical benchmark.
+- **88.0%** on Terminal-Bench 2.1 and **64.5%** on Humanity's Last Exam (with tools).
+
+Translation for practitioners: this is a model strong enough to meaningfully accelerate software engineering, threat research, detection engineering, and the kind of analytical knowledge work that fills a SOC analyst's day.
+
+---
+
+## The Safeguard That Makes Public Release Possible
+
+Here's the part security professionals should pay closest attention to.
+
+Anthropic says Fable 5's broad release is only possible because of a new **fallback safeguard**. When a user touches a defined high-risk area — **cybersecurity, biology, chemistry, or distillation** — Fable 5 declines to answer with its full capability and instead falls back to **Claude Opus 4.8** to deliver a safer response.
+
+Ask it how to synthesize a toxin like ricin, and it won't just refuse; it routes the request to a less capable, more conservative model. Anthropic reports this fallback triggers in **fewer than 5% of sessions**.
+
+This is a meaningful shift in mental model:
+
+1. **Capability and safety are now decoupled at runtime.** The model decides, per request, *which version of itself* you get.
+2. **"Refusal" is becoming "downgrade."** Instead of a hard no, you get a quieter, less capable yes.
+3. **The risk taxonomy is explicit.** Cybersecurity sits right next to bio and chem on the list of domains too dangerous to leave unguarded by default.
+
+For defenders, that last point is the tell: AI labs now treat offensive cyber capability as a CBRN-adjacent risk.
+
+---
+
+## Mythos 5 and Project Glasswing
+
+If Fable 5 is the frontier with the dangerous edges sanded off, **Mythos 5 is the edge itself.**
+
+Mythos 5 is being deployed first through **Project Glasswing** — Anthropic's collaboration with the US government to put frontier capability in the hands of cyber defenders and critical-infrastructure providers. It's an upgrade to the earlier Claude Mythos Preview, and Anthropic describes it as having the **strongest cybersecurity capabilities of any model in the world.**
+
+Access is deliberately narrow:
+
+- **Restricted distribution** through Project Glasswing rather than the public API.
+- Aimed at **vetted cybersecurity professionals** and critical-infrastructure defenders.
+- A planned expansion to a more **systematic trusted-access program** over time.
+
+The strategic logic is straightforward — and worth internalizing as a leader: the *same* capability that supercharges a defender supercharges an attacker. Anthropic's bet is that you can hand the full toolkit to one side through a controlled, identity-verified pipeline while denying it to the open internet.
+
+---
+
+## Pricing and Availability
+
+Both models are priced identically:
+
+- **$10 per million input tokens**
+- **$50 per million output tokens**
+- A **90% discount on input tokens** via prompt caching.
+
+That's **less than half the price** of Claude Mythos Preview — a notable signal that frontier-class capability is getting cheaper even as it gets more tightly governed.
+
+---
+
+## A Mental Model for Every Stakeholder
+
+This release rewards a clear head. Here's how to think about it depending on where you sit:
+
+- **For Security Leaders:** Treat AI capability as a *governed asset*, not a flat feature. The Fable/Mythos split is exactly the access-control discipline you already apply to privileged systems — least privilege, identity-gated access, and capability tiering. Map your own AI usage policy to that model now, before your teams build workflows on the unrestricted edge.
+- **For Defenders and Analysts:** Lean into the public model for engineering, triage, and research throughput — but understand *why* it falls back. Knowing where the guardrails sit helps you design prompts and pipelines that stay productive without tripping safeguards.
+- **For Aspiring Professionals:** The bar for "valuable human in the loop" is rising. The edge isn't running the tool; it's judgment, verification, and accountability around what the tool produces. Build projects that demonstrate exactly that.
+
+---
+
+## Final Thoughts
+
+The Fable 5 / Mythos 5 launch is the clearest statement yet that frontier AI and cybersecurity have fully converged. The most capable model on the planet now ships in two versions because its cyber capabilities are too sharp to release unguarded — and the defenders who get the full edge get it through a government-backed, controlled channel.
+
+That's not a footnote. It's the new operating reality for everyone in this field.
+
+If you found this helpful, learn the thinking that separates leaders from followers.
+
+🚀 Supercharge Your Cybersecurity Career with [**CyberSHIELD PRO Membership**](https://cybersecurityos.gumroad.com/l/cybershield-membership) – Unlock Exclusive Benefits Today!
+
+---
+
+Stay informed, stay empowered,
+**CyberSHIELD | CybersecurityOS**
+
+---
+
+### Sources
+
+- [Claude Fable 5 and Claude Mythos 5 — Anthropic](https://www.anthropic.com/news/claude-fable-5-mythos-5)
+- [Anthropic releases Mythos-like AI model to the public, Claude Fable 5 — CNBC](https://www.cnbc.com/2026/06/09/anthropic-mythos-claude-fable-5.html)
+- [Anthropic releases Fable 5, the first public Mythos-class model — NBC News](https://www.nbcnews.com/tech/security/fable-5-anthropic-release-public-mythos-claude-model-rcna349104)
+- [Anthropic Launches Claude Fable 5, Its First Public Mythos-Class Model — MacRumors](https://www.macrumors.com/2026/06/09/anthropic-fable-5/)
+- [Claude Fable 5 & Claude Mythos 5 Benchmarks Explained — Vellum](https://www.vellum.ai/blog/claude-fable-5-and-mythos-5-benchmarks-explained)
+- [Claude Fable 5 & Mythos 5: The Frontier, Split in Two — Digital Applied](https://www.digitalapplied.com/blog/claude-fable-5-mythos-5-release-benchmarks-2026)


### PR DESCRIPTION
## Summary
Add a new blog post analyzing Anthropic's Claude Fable 5 and Mythos 5 release, focusing on the implications for cybersecurity professionals, leaders, and defenders.

## Changes
- **New post:** `content/posts/os-weekly/claude-fable-5-mythos-5.md`
  - Comprehensive analysis of the dual-model release strategy (Fable 5 for public, Mythos 5 for restricted access)
  - Breakdown of key benchmarks and capabilities (SWE-Bench Pro, Hex analytical benchmark, etc.)
  - Explanation of the fallback safeguard mechanism for high-risk domains
  - Strategic context on Project Glasswing and government-backed access controls
  - Pricing and availability details
  - Actionable mental models for security leaders, defenders, and aspiring professionals
  - Includes metadata (tags, categories, description) and call-to-action links to CybersecurityOS resources

## Notable Details
- Published date: June 10, 2026 (day after announcement)
- Positioned as a governance and strategy piece, not just a capability announcement
- Emphasizes the convergence of frontier AI and cybersecurity as a field-defining moment
- Includes 6 source citations for credibility

https://claude.ai/code/session_01KjPZ75G416WM93FMtZnHtV