### PR TITLE
fix(layouts): individual tag/category pages were rendering empty

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -7,18 +7,13 @@
   </div>
   {{ end }}
 
-  <!-- All terms (tags/categories) as a badge grid -->
-  <div style="max-width:1200px;margin:2rem auto;padding:0 1.5rem;">
-    <ul class="os-tags" style="gap:.5rem;">
-      {{ range .Data.Terms.Alphabetical }}
-        <li style="display:inline;">
-          <a href="{{ .Page.RelPermalink }}" class="os-tag" style="font-size:.8rem;padding:.3rem .8rem;">
-            {{ .Page.LinkTitle }}
-            <span style="opacity:.55;font-size:.7em;margin-left:.3rem;">({{ .Count }})</span>
-          </a>
-        </li>
-      {{ end }}
-    </ul>
+  <!-- Post card grid for this tag/category -->
+  <div class="os-card-grid">
+    {{ range .Paginator.Pages }}
+      {{ .Render "summary" }}
+    {{ end }}
   </div>
+
+  {{- template "_internal/pagination.html" . -}}
 
 {{ end }}


### PR DESCRIPTION
## Summary
- Found why `/tags/<tag>/` and `/categories/<category>/` term pages render empty: `layouts/_default/taxonomy.html` was using `.Data.Terms.Alphabetical` (a list-page concept for `/tags/` and `/categories/`) instead of `.Paginator.Pages`, which is needed to list the posts belonging to that specific term.
- Updated `taxonomy.html` to render a post card grid + pagination, matching the existing pattern in `terms.html` and `list.html`.

## Test plan
- [x] `rm -rf public && hugo --gc --minify`
- [x] Verified `public/categories/leadership/index.html`, `public/tags/cybersecurityos/index.html`, and `public/categories/ai--security/index.html` now contain populated `os-card-grid` post cards
- [ ] Spot-check a few `/tags/<tag>/` and `/categories/<category>/` pages on the deployed site