### PR TITLE
chore: refresh homepage stats and tidy taxonomy/styling

### DIFF
--- a/assets/css/cybersecurityos.css
+++ b/assets/css/cybersecurityos.css
@@ -994,8 +994,9 @@ article.pa3, article.pa4-ns { background: transparent !important; }
   gap: 0; padding: 1.25rem 1.5rem; flex-wrap: wrap;
 }
 .fm-proof-stat { text-align: center; padding: 0.5rem 2rem; }
-.fm-proof-num   { font-family: var(--os-font-heading); font-size: 1.3rem; font-weight: 700; color: var(--os-green); display: block; }
-.fm-proof-label { font-family: var(--os-font-mono); font-size: 0.65rem; color: var(--os-text-dim); text-transform: uppercase; letter-spacing: 0.1em; display: block; margin-top: 0.2rem; }
+/* Shares the .os-stat-value / .os-stat-label component used in the homepage hero */
+.fm-proof-stat .os-stat-value { font-size: 1.3rem; }
+.fm-proof-stat .os-stat-label { font-size: 0.65rem; margin-top: 0.2rem; }
 .fm-proof-divider { width: 1px; height: 2.5rem; background: var(--os-border); flex-shrink: 0; }
 
 /* ── Problem ─── */

--- a/content/posts/os-weekly/audit-season-readiness-2025.md
+++ b/content/posts/os-weekly/audit-season-readiness-2025.md
@@ -3,7 +3,7 @@ title: "How to Prepare for Audit Season: A Cybersecurity Leader’s Guide to SOC
 date: 2025-11-09
 description: "Learn how cybersecurity professionals can prepare for audit season across SOC 2, ISO 27001, and NIST frameworks by mastering governance, risk management, control assurance, and compliance readiness."
 tags: ["Cybersecurity", "CybersecurityOS", "SOC2", "ISO27001", "NIST", "audit readiness", "governance", "compliance", "risk management", "assurance"]
-categories: ["GRC & Compliance"]
+categories: ["GRC and Compliance"]
 slug: "audit-season-readiness-2025"
 draft: false
 images:

--- a/content/posts/os-weekly/claude-fable-5-mythos-5.md
+++ b/content/posts/os-weekly/claude-fable-5-mythos-5.md
@@ -3,7 +3,7 @@ title: "The Frontier, Split in Two: What Claude Fable 5 and Mythos 5 Mean for Cy
 date: 2026-06-10
 draft: false
 tags: ["CybersecurityOS", "Cybersecurity", "Artificial Intelligence", "Claude", "Anthropic", "AI Safety", "Cyber Defense"]
-categories: ["AI & Security"]
+categories: ["AI and Security"]
 description: "Anthropic just released Claude Fable 5 — its most capable public model ever — alongside Claude Mythos 5, the most powerful cybersecurity model in the world. Here's what the split-frontier strategy means for defenders, leaders, and aspiring professionals."
 slug: "claude-fable-5-mythos-5-cybersecurity"
 show_reading_time: true

--- a/content/posts/os-weekly/cyber-careers-2025.md
+++ b/content/posts/os-weekly/cyber-careers-2025.md
@@ -4,7 +4,7 @@ date: 2025-10-02
 draft: false
 description: "Explore the evolving world of cybersecurity careers, the transformative impact of AI in Security Operations Centers, and the rise of GRC engineering. Learn practical insights for aspiring professionals and discover how curiosity, mentorship, and automation are shaping the future of security."
 tags: ["Cybersecurity", "AI", "SOC", "cloud security", "GRC","CyberSHIELD", "CybersecurityOS"]
-categories: ["Career Development", "AI & Security"]
+categories: ["Career Development", "AI and Security"]
 images:
     -  /posts/os-weekly/images/cyber-careers-2025.png
 featured_image:  /posts/os-weekly/images/cyber-careers-2025.png

--- a/content/posts/os-weekly/cyber-resilience-3-0.md
+++ b/content/posts/os-weekly/cyber-resilience-3-0.md
@@ -3,7 +3,7 @@ title: "Cyber Resilience 3.0: From Sanctions Gaps to Stress-Test Sharks and Open
 date: 2025-07-06
 description: "Explore the evolving frontiers of cybersecurity: regulatory blind spots, real-world resilience lessons from a mechanical shark, and how open source is reshaping cyber policy."
 tags: ["CybersecurityOS","Cybersecurity", "resilience", "open source", "compliance", "cyber policy"]
-categories: ["Cyber Policy & Resilience"]
+categories: ["Cyber Policy and Resilience"]
 slug: "cyber-resilience-3-0"
 draft: false
 images:

--- a/content/posts/os-weekly/cyber-resilience-real-time.md
+++ b/content/posts/os-weekly/cyber-resilience-real-time.md
@@ -3,7 +3,7 @@ title: "Cyber Resilience in Real Time: New Realities, Rapid Responses, and Next-
 date: 2025-07-13
 description: "From global arrests to legacy system failures, the threat landscape is evolving. Here's a 3-step framework to modernize your cybersecurity defense and stay ahead."
 tags: ["CybersecurityOS","Cybersecurity", "AI", "vulnerability management", "cross-border", "incident response"]
-categories: ["Cyber Policy & Resilience", "AI & Security"]
+categories: ["Cyber Policy and Resilience", "AI and Security"]
 slug: "cyber-resilience-real-time"
 draft: false
 images:

--- a/content/posts/os-weekly/deconstructing-emerging-cyber-threat-vectors.md
+++ b/content/posts/os-weekly/deconstructing-emerging-cyber-threat-vectors.md
@@ -6,7 +6,7 @@ images:
 featured_image:  /posts/os-weekly/images/discord.png
 description: "Explore the latest tactics used by cyber adversaries — from Discord link hijacking to strategic shifts in tech alliances — and how cybersecurity leaders can respond."
 tags: ["Cybersecurity", "malware", "policy", "risk management", "tech strategy", "CybersecurityOS"]
-categories: ["Threat Intelligence", "Cyber Policy & Resilience"]
+categories: ["Threat Intelligence", "Cyber Policy and Resilience"]
 slug: "deconstructing-emerging-cyber-threat-vectors"
 draft: false
 ---

--- a/content/posts/os-weekly/navigating-evolving-cybersecurity-landscape.md
+++ b/content/posts/os-weekly/navigating-evolving-cybersecurity-landscape.md
@@ -6,7 +6,7 @@ images:
 featured_image:  /posts/os-weekly/images/adtech.png
 description: "Explore the latest trends in dark ad tech, disinformation, self-aware cybersecurity strategies, and policy impacts — for both leaders and aspiring professionals."
 tags: ["Cybersecurity", "disinformation", "adtech", "strategy", "policy","CybersecurityOS"]
-categories: ["Threat Intelligence", "Cyber Policy & Resilience"]
+categories: ["Threat Intelligence", "Cyber Policy and Resilience"]
 slug: "navigating-evolving-cybersecurity-landscape"
 draft: false
 ---

--- a/content/posts/os-weekly/security-kpis-board-reporting.md
+++ b/content/posts/os-weekly/security-kpis-board-reporting.md
@@ -4,7 +4,7 @@ date: 2026-06-03
 draft: false
 author: "Michael Tayo"
 tags: ["CISO", "security KPIs", "board reporting", "cybersecurity metrics", "security leadership", "NIST CSF", "ISO 27001", "CybersecurityOS", "risk management", "cyber risk"]
-categories: ["Leadership", "GRC & Compliance", "Frameworks"]
+categories: ["Leadership", "GRC and Compliance", "Frameworks"]
 slug: "security-kpis-board-reporting"
 description: "Most CISOs report the wrong security metrics to the board. This guide covers the KPIs that actually matter — mapped to business risk, boardroom language, and real-world examples from organizations like Target, MGM, and Equifax."
 images:

--- a/content/posts/os-weekly/spectra-overview-claude-ai-security.md
+++ b/content/posts/os-weekly/spectra-overview-claude-ai-security.md
@@ -3,7 +3,7 @@ title: "SPECTRA: AI-Powered Vulnerability Triage That Actually Works for Securit
 date: 2026-05-10
 description: "SPECTRA is an open-source, AI-powered CLI that transforms raw scanner output from Trivy, Semgrep, and Nessus into ranked findings, attack chain analysis, and executive summaries — powered by Claude. Here's why it matters for modern security teams."
 tags: ["AI", "DevSecOps", "Automation", "Vulnerability Management", "Claude", "Security Engineering", "SAST", "Trivy", "Semgrep", "AppSec", "GRC", "Shift Left Security"]
-categories: ["AI & Security", "Security Engineering"]
+categories: ["AI and Security", "Security Engineering"]
 keywords: ["AI vulnerability triage", "AI security scanner", "SPECTRA security tool", "Claude AI security", "vulnerability management automation", "DevSecOps tools 2026", "attack chain analysis", "security triage automation", "Trivy AI analysis", "Semgrep triage", "open source security AI"]
 draft: false
 images:

--- a/content/posts/os-weekly/top-5-claude-ai-use-cases-startup-cybersecurity-2026.md
+++ b/content/posts/os-weekly/top-5-claude-ai-use-cases-startup-cybersecurity-2026.md
@@ -15,7 +15,7 @@ tags:
   - supply-chain
   - soar
 categories:
-  - AI & Security
+  - AI and Security
   - Security Engineering
 slug: "claude-ai-use-cases-startup-cybersecurity-2026"
 images:

--- a/layouts/_default/founding-member.html
+++ b/layouts/_default/founding-member.html
@@ -45,23 +45,23 @@
   <div class="fm-proof-bar">
     <div class="fm-proof-bar-inner">
       <div class="fm-proof-stat">
-        <span class="fm-proof-num">18+</span>
-        <span class="fm-proof-label">posts in the OS</span>
+        <span class="os-stat-value">21+</span>
+        <span class="os-stat-label">posts in the OS</span>
       </div>
       <div class="fm-proof-divider"></div>
       <div class="fm-proof-stat">
-        <span class="fm-proof-num">10yr</span>
-        <span class="fm-proof-label">practitioner experience</span>
+        <span class="os-stat-value">10yr</span>
+        <span class="os-stat-label">practitioner experience</span>
       </div>
       <div class="fm-proof-divider"></div>
       <div class="fm-proof-stat">
-        <span class="fm-proof-num">Deputy CISO</span>
-        <span class="fm-proof-label">author &amp; curator</span>
+        <span class="os-stat-value">Deputy CISO</span>
+        <span class="os-stat-label">author &amp; curator</span>
       </div>
       <div class="fm-proof-divider"></div>
       <div class="fm-proof-stat">
-        <span class="fm-proof-num">$15/mo</span>
-        <span class="fm-proof-label">founding rate, locked forever</span>
+        <span class="os-stat-value">$15/mo</span>
+        <span class="os-stat-label">founding rate, locked forever</span>
       </div>
     </div>
   </div>

--- a/layouts/founding-member/single.html
+++ b/layouts/founding-member/single.html
@@ -45,23 +45,23 @@
   <div class="fm-proof-bar">
     <div class="fm-proof-bar-inner">
       <div class="fm-proof-stat">
-        <span class="fm-proof-num">18+</span>
-        <span class="fm-proof-label">posts in the OS</span>
+        <span class="os-stat-value">21+</span>
+        <span class="os-stat-label">posts in the OS</span>
       </div>
       <div class="fm-proof-divider"></div>
       <div class="fm-proof-stat">
-        <span class="fm-proof-num">10yr</span>
-        <span class="fm-proof-label">practitioner experience</span>
+        <span class="os-stat-value">10yr</span>
+        <span class="os-stat-label">practitioner experience</span>
       </div>
       <div class="fm-proof-divider"></div>
       <div class="fm-proof-stat">
-        <span class="fm-proof-num">Deputy CISO</span>
-        <span class="fm-proof-label">author &amp; curator</span>
+        <span class="os-stat-value">Deputy CISO</span>
+        <span class="os-stat-label">author &amp; curator</span>
       </div>
       <div class="fm-proof-divider"></div>
       <div class="fm-proof-stat">
-        <span class="fm-proof-num">$15/mo</span>
-        <span class="fm-proof-label">founding rate, locked forever</span>
+        <span class="os-stat-value">$15/mo</span>
+        <span class="os-stat-label">founding rate, locked forever</span>
       </div>
     </div>
   </div>

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -62,7 +62,7 @@
       </div>
       <div class="os-hero-stats">
         <div>
-          <span class="os-stat-value">18+</span>
+          <span class="os-stat-value">21+</span>
           <span class="os-stat-label">Weekly Posts</span>
         </div>
         <div>


### PR DESCRIPTION
## Summary
- Updated the homepage hero "Weekly Posts" stat from 18+ to 21+ to match the actual os-weekly post count (also updated the founding-member proof bar to match).
- Renamed categories using "&" ("AI & Security", "GRC & Compliance", "Cyber Policy & Resilience") to "and" variants so taxonomy URLs no longer get ugly double-hyphen slugs (`ai--security` -> `ai-and-security`, etc.) across 10 affected posts.
- Consolidated the founding-member proof bar's `.fm-proof-num`/`.fm-proof-label` styles into the shared `.os-stat-value`/`.os-stat-label` component already used by the homepage hero stats.

## Test plan
- [x] `rm -rf public && hugo --gc --minify` — clean build, no errors
- [x] `npx markdownlint-cli content/posts/os-weekly/*.md` — passes
- [x] Verified `/categories/ai-and-security/`, `/categories/grc-and-compliance/`, `/categories/cyber-policy-and-resilience/` exist in build output
- [x] Verified homepage hero shows "21+ Weekly Posts" and founding-member proof bar renders with shared stat styles