### PR TITLE
UI/UX pass: card tags, table overflow, related posts, contrast

### DIFF
--- a/assets/css/cybersecurityos.css
+++ b/assets/css/cybersecurityos.css
@@ -33,7 +33,7 @@
   /* Text */
   --os-text:       #e6edf3;
   --os-text-muted: #8b949e;
-  --os-text-dim:   #484f58;
+  --os-text-dim:   #6e7681;
 
   /* Fonts */
   --os-font-heading: 'Orbitron', 'Segoe UI', sans-serif;
@@ -373,6 +373,22 @@ article.pa3, article.pa4-ns { background: transparent !important; }
   transition: opacity 0.2s;
 }
 .os-card:hover .os-card-img { opacity: 1; }
+.os-card-img--placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background:
+    linear-gradient(var(--os-border) 1px, transparent 1px) 0 0 / 100% 16px,
+    linear-gradient(90deg, var(--os-border) 1px, transparent 1px) 0 0 / 16px 100%,
+    var(--os-bg-elevated);
+}
+.os-card-img--placeholder span {
+  font-family: var(--os-font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--os-text-dim);
+}
 
 .os-card-body {
   padding: 1.25rem;
@@ -466,6 +482,7 @@ article.pa3, article.pa4-ns { background: transparent !important; }
 .os-tag--purple:hover { background: rgba(163,113,247,0.14); }
 .os-tag--red    { color: var(--os-critical); border-color: rgba(255,69,58,0.30);    background: rgba(255,69,58,0.07); }
 .os-tag--red:hover    { background: rgba(255,69,58,0.14); }
+.os-tag--more   { color: var(--os-text-dim); border-color: var(--os-border); background: transparent; }
 
 /* ─── Single Post / Article ─────────────────────────────────── */
 .os-article-wrap {
@@ -478,6 +495,18 @@ article.pa3, article.pa4-ns { background: transparent !important; }
   margin-bottom: 2.5rem;
   padding-bottom: 1.5rem;
 }
+.os-article-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-family: var(--os-font-mono);
+  font-size: 0.72rem;
+  color: var(--os-text-muted);
+  text-decoration: none;
+  margin-bottom: 1.25rem;
+  transition: color 0.15s;
+}
+.os-article-back:hover { color: var(--os-green); }
 .os-article-section {
   font-family: var(--os-font-mono);
   font-size: 0.68rem;
@@ -599,13 +628,18 @@ article.pa3, article.pa4-ns { background: transparent !important; }
   line-height: 1.65;
 }
 
-/* Tables */
+/* Tables — wrapped in .os-table-wrap at runtime so wide tables scroll on mobile */
+.os-table-wrap {
+  overflow-x: auto;
+  margin: 1.75rem 0;
+  -webkit-overflow-scrolling: touch;
+}
 .os-prose table {
   width: 100%;
   border-collapse: collapse;
-  margin: 1.75rem 0;
   font-size: 0.875rem;
 }
+.os-table-wrap table { margin: 0; }
 .os-prose thead th {
   font-family: var(--os-font-mono);
   font-size: 0.68rem;

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -99,6 +99,15 @@
           toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
         });
       })();
+      // Wrap wide tables so they scroll horizontally on small screens
+      (function(){
+        document.querySelectorAll('.os-prose table').forEach(function(table) {
+          var wrap = document.createElement('div');
+          wrap.className = 'os-table-wrap';
+          table.parentNode.insertBefore(wrap, table);
+          wrap.appendChild(table);
+        });
+      })();
     </script>
     <!-- Kit: popup (late load — fires after page is interactive) -->
     <script async data-uid="216ee976c6" src="https://theghettoflower.kit.com/216ee976c6/index.js"></script>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,6 +10,11 @@
 
     <!-- Article header -->
     <header class="os-article-header">
+      {{ with .CurrentSection }}
+        {{ if not .IsHome }}
+        <a href="{{ .RelPermalink }}" class="os-article-back">&larr; Back to {{ .Title | default $.Section }}</a>
+        {{ end }}
+      {{ end }}
       <p class="os-article-section">
         {{ .CurrentSection.Title | default .Section }}
       </p>
@@ -71,8 +76,14 @@
       {{ partial "social-share.html" . }}
     </div>
 
-    <!-- Related posts -->
-    {{ $related := .Site.RegularPages.Related . | first 3 }}
+    <!-- Related posts (prefer same-section matches, fall back to site-wide) -->
+    {{ $sectionPages := where .Site.RegularPages "Section" .Section }}
+    {{ $sectionRelated := $sectionPages.Related . | first 3 }}
+    {{ $related := $sectionRelated }}
+    {{ if lt (len $related) 3 }}
+      {{ $more := .Site.RegularPages.Related . | first 3 }}
+      {{ $related = (union $sectionRelated $more) | first 3 }}
+    {{ end }}
     {{ with $related }}
     <aside class="os-related" aria-label="Related posts">
       <h2 class="os-related-heading">Related Posts</h2>

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -11,6 +11,10 @@
           "alt"      .Title
           "class"    "os-card-img") }}
     </a>
+  {{ else }}
+    <a href="{{ .RelPermalink }}" tabindex="-1" aria-hidden="true" class="os-card-img os-card-img--placeholder">
+      <span>{{ .CurrentSection.Title | default .Section }}</span>
+    </a>
   {{ end }}
 
   <div class="os-card-body">
@@ -20,8 +24,8 @@
 
     <p class="os-card-excerpt">{{ .Summary | plainify | truncate 120 }}</p>
 
-    {{/* Tags */}}
-    {{ partial "tags.html" . }}
+    {{/* Tags (capped to keep card heights consistent) */}}
+    {{ partial "tags.html" (dict "page" . "limit" 4) }}
 
     {{/* Card footer */}}
     <div class="os-card-footer">

--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,8 +1,21 @@
-{{/* CVE-style severity tag badges */}}
-{{ $terms := .GetTerms "tags" }}
+{{/* CVE-style severity tag badges.
+  Usage: partial "tags.html" . — render all tags for the page
+         partial "tags.html" (dict "page" . "limit" 4) — cap tags shown, with a "+N" overflow badge
+*/}}
+{{ $page := . }}
+{{ $limit := 0 }}
+{{ if reflect.IsMap . }}
+  {{ $page = .page }}
+  {{ $limit = .limit | default 0 }}
+{{ end }}
+{{ $terms := $page.GetTerms "tags" }}
 {{ if $terms }}
 <ul class="os-tags">
-  {{ range $terms }}
+  {{ $shown := $terms }}
+  {{ if and (gt $limit 0) (gt (len $terms) $limit) }}
+    {{ $shown = first $limit $terms }}
+  {{ end }}
+  {{ range $shown }}
     {{ $slug := .LinkTitle | lower }}
     {{ $class := "os-tag" }}
     {{/* Map tag keywords to severity color classes */}}
@@ -19,6 +32,11 @@
       <a href="{{ .RelPermalink }}" class="{{ $class }}" data-tag="{{ $slug }}">
         {{- .LinkTitle -}}
       </a>
+    </li>
+  {{ end }}
+  {{ if and (gt $limit 0) (gt (len $terms) $limit) }}
+    <li class="list" style="display:inline;">
+      <span class="os-tag os-tag--more">+{{ sub (len $terms) $limit }}</span>
     </li>
   {{ end }}
 </ul>


### PR DESCRIPTION
## Summary

Top 10 UI/UX findings from a holistic review; this PR implements the 6 safe, code-level fixes:

1. **Tag overload on cards** — `tags.html` now accepts an optional `limit` (with a "+N" overflow badge); `summary.html` caps cards to 4 tags so the card grid keeps a consistent rhythm.
2. **Wide tables overflow on mobile** — `.os-prose` tables are wrapped in a scrollable `.os-table-wrap` at runtime, so multi-column tables (e.g. STRIDE) scroll horizontally instead of blowing out the page on small screens.
3. **Low-contrast muted text** — `--os-text-dim` raised from `#484f58` to `#6e7681` for better contrast on dates/labels against the dark background.
4. **Related Posts scoping** — single posts now prefer same-section related matches before falling back to site-wide, so a leadership post won't surface an unrelated Python/cloud post.
5. **Back-link on articles** — added a "← Back to {section}" link in the article header for orientation.
6. **Featured-image fallback** — cards without a `featured_image` (currently 1 post) now render a placeholder block so the grid stays visually consistent.

### Flagged but not implemented (need a product/content call)
7. Two near-duplicate founding-member templates — maintenance risk, out of UI/UX scope.
8. Stacked email-capture CTAs (sticky banner + popup + footer + in-content promos) — content/marketing decision.
9. External prose links open same-tab with no indicator — subjective UX tradeoff.
10. Mobile nav doesn't auto-close on in-page anchor clicks — minor, low impact.

## Test plan
- [x] `rm -rf public && hugo --gc --minify` — clean build, 331 pages, no errors
- [x] Verified capped tags + "+N" badge render on cards with >4 tags
- [x] Verified placeholder image renders for the one post without `featured_image`
- [x] Verified table-wrap script and CSS present in minified output
- [x] Verified "Back to Posts" link renders on a single post
- [x] Verified contrast color and new classes present in minified CSS