### PR TITLE
copy: marketing pass on SEO description and About page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -2,5 +2,5 @@
 title = "CybersecurityOS"
 date = 2024-09-25T23:19:07-05:00
 draft = false
-description = "Engineering security from first principles. "
+description = "Weekly security intelligence and battle-tested mental models for security engineers and CISOs. Engineering security from first principles — written by a practicing Deputy CISO."
 +++

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -29,3 +29,7 @@ I'm working on turning these frameworks and insights into a comprehensive guide 
 When I'm not thinking about security architecture, you'll find me exploring the intersections of fitness, travel, music, and food.
 
 Let's build more resilient systems together.
+
+## Go Deeper
+
+If these frameworks are useful, **[become an OS Member](/founding-member/)** — the founding-rate membership for security leaders who want the deeper playbooks, templates, and frameworks behind the weekly posts. Not ready for that yet? Start with the **[free weekly posts](/posts/)**.

--- a/hugo.toml
+++ b/hugo.toml
@@ -4,8 +4,8 @@ title = "CybersecurityOS"
 theme = "ananke"
 
 # SEO Metadata
-description = "A comprehensive resource for cybersecurity professionals, providing insights, tools, and services."
-keywords = "cybersecurity, security tools, professional development, best practices"
+description = "Weekly security intelligence, mental models, and leadership frameworks for security engineers, CISOs, and the next generation of cyber leaders — written by a practicing Deputy CISO."
+keywords = "cybersecurity, security leadership, CISO frameworks, security engineering, threat intelligence, AI security, DevSecOps, mental models, cyber risk management"
 author = "Michael Tayo"
 # To enable Google Analytics add your tracking ID:
 # [services.googleAnalytics]


### PR DESCRIPTION
## Summary
- Updates the site-wide SEO description and keywords in `hugo.toml` (used as the meta-description fallback and JSON-LD `WebSite` description on every page) to reflect the actual brand positioning — Deputy CISO voice, mental models, leadership frameworks — instead of generic boilerplate.
- Updates the homepage-specific meta description in `content/_index.md` with the same positioning.
- Adds a "Go Deeper" closing section to the About page with CTAs to OS Member (`/founding-member/`) and the free weekly posts (`/posts/`), turning a previous dead-end into a conversion point.

## Test plan
- [x] `rm -rf public && hugo --gc --minify` — 331 pages, no errors
- [x] Verified homepage meta description renders the new copy in `public/index.html`
- [x] Verified About page renders the new "Go Deeper" section with working links
- [x] `markdownlint` passes on changed content files