### PR TITLE
Reposition SPECTRA landing page around four buyer workflows

### DIFF
--- a/layouts/_default/spectra-landing.html
+++ b/layouts/_default/spectra-landing.html
@@ -384,7 +384,7 @@ footer {
   <div class="scan-hero"></div>
   <p class="hero-label">▸ AI VULNERABILITY INTELLIGENCE · OPEN SOURCE</p>
   <h1 class="hero-title">SPECTRA</h1>
-  <p class="hero-sub">One CLI that turns scanner noise into the artifact your team actually needs — a prioritized remediation plan, a CI/CD security signal, a red team narrative, or board-ready compliance evidence.</p>
+  <p class="hero-sub">SPECTRA turns raw scanner output into the artifact your team actually needs — a prioritized remediation plan, security context in your CI/CD pipeline, a compelling attack narrative, or a board-ready risk report.</p>
   <div class="hero-actions">
     <a href="/docs/spectra/quickstart/" class="btn-primary">GET STARTED →</a>
     <a href="#usecases" class="btn-secondary">SEE USE CASES ↓</a>

--- a/layouts/_default/spectra-landing.html
+++ b/layouts/_default/spectra-landing.html
@@ -384,7 +384,7 @@ footer {
   <div class="scan-hero"></div>
   <p class="hero-label">▸ AI VULNERABILITY INTELLIGENCE · OPEN SOURCE</p>
   <h1 class="hero-title">SPECTRA</h1>
-  <p class="hero-sub">SPECTRA turns raw scanner output into the artifact your team actually needs — a prioritized remediation plan, security context in your CI/CD pipeline, a compelling attack narrative, or a board-ready risk report.</p>
+  <p class="hero-sub">SPECTRA turns raw scanner output into the artifact your team actually needs, whether that's a prioritized remediation plan, security context in your CI/CD pipeline, a compelling attack narrative, or a board-ready risk report.</p>
   <div class="hero-actions">
     <a href="/docs/spectra/quickstart/" class="btn-primary">GET STARTED →</a>
     <a href="#usecases" class="btn-secondary">SEE USE CASES ↓</a>
@@ -415,20 +415,20 @@ footer {
 <section id="usecases">
   <span class="section-label">// WHO IT'S FOR</span>
   <h2 class="section-title">Built for Four<br>Production Workflows.</h2>
-  <p class="section-body">131 new CVEs land today. Almost none of them matter. SPECTRA decides which ones do — and turns that decision into the artifact each of these workflows actually needs.</p>
+  <p class="section-body">131 new CVEs land today. Almost none of them matter. SPECTRA decides which ones do, then turns that decision into the artifact each of these workflows actually needs.</p>
   <div class="usecase-list">
     <div class="usecase" id="usecase-vulnmgmt">
       <div class="usecase-icon">◆</div>
       <span class="usecase-tag">FOR APPSEC &amp; VULN MANAGEMENT TEAMS</span>
       <div class="usecase-title">VULNERABILITY MANAGEMENT</div>
-      <p class="usecase-desc">Stop drowning in scanner output. SPECTRA ranks what matters, chains what connects, and produces the prioritized remediation plan your team needs — not a spreadsheet of CVEs sorted by CVSS.</p>
+      <p class="usecase-desc">Stop drowning in scanner output. SPECTRA ranks what matters, chains what connects, and produces the prioritized remediation plan your team needs, not another spreadsheet of CVEs sorted by CVSS.</p>
       <a href="/docs/spectra/quickstart/" class="usecase-cta">→ RUN YOUR FIRST ANALYSIS</a>
     </div>
     <div class="usecase" id="usecase-devsecops">
       <div class="usecase-icon">⚙</div>
       <span class="usecase-tag">FOR PLATFORM &amp; DEVOPS ENGINEERS</span>
       <div class="usecase-title">DEVSECOPS PIPELINE</div>
-      <p class="usecase-desc">Plug SPECTRA into your CI/CD pipeline and get actionable security context on every build — without flooding developers with noise that kills velocity and trust.</p>
+      <p class="usecase-desc">Plug SPECTRA into your CI/CD pipeline and get actionable security context on every build, without flooding developers with noise that kills velocity and trust.</p>
       <a href="/docs/spectra/cicd-integration/" class="usecase-cta">→ VIEW CI/CD INTEGRATION GUIDE</a>
     </div>
     <div class="usecase" id="usecase-redteam">
@@ -442,7 +442,7 @@ footer {
       <div class="usecase-icon">▤</div>
       <span class="usecase-tag">FOR GRC &amp; COMPLIANCE OFFICERS</span>
       <div class="usecase-title">GRC &amp; COMPLIANCE REPORTING</div>
-      <p class="usecase-desc">Generate board-ready risk summaries automatically — technical findings translated into the business-risk language your leadership and auditors expect, without the manual write-up overhead.</p>
+      <p class="usecase-desc">Generate board-ready risk summaries automatically, with technical findings translated into the business-risk language your leadership and auditors expect, without the manual write-up overhead.</p>
       <a href="/docs/spectra/output-formats/#json-report-structure" class="usecase-cta">→ SEE JSON REPORT STRUCTURE</a>
     </div>
   </div>
@@ -454,7 +454,7 @@ footer {
 <section id="problem">
   <span class="section-label">// THE PROBLEM</span>
   <h2 class="section-title">CVSS Scores Are Broken.<br>Your Team Is Paying For It.</h2>
-  <p class="section-body">Traditional vulnerability management tools score severity in isolation — not whether the exploit path is reachable in your environment, not what attackers are actively using, not what your CISO needs to hear.</p>
+  <p class="section-body">Traditional vulnerability management tools score severity in isolation. They don't account for whether the exploit path is reachable in your environment, what attackers are actively using, or what your CISO needs to hear.</p>
   <div class="problem-grid">
     <div class="problem-card">
       <div class="problem-num">01</div>
@@ -464,7 +464,7 @@ footer {
     <div class="problem-card">
       <div class="problem-num">02</div>
       <div class="problem-title">TRIAGE OVERLOAD</div>
-      <p class="problem-text">With 131 new CVEs per day and a 4.8 million person workforce gap, manual triage isn't just slow — it's burning analyst time on findings that will never be exploited.</p>
+      <p class="problem-text">With 131 new CVEs per day and a 4.8 million person workforce gap, manual triage isn't just slow, it's burning analyst time on findings that will never be exploited.</p>
     </div>
     <div class="problem-card">
       <div class="problem-num">03</div>
@@ -480,7 +480,7 @@ footer {
 <section id="features">
   <span class="section-label">// WHAT SPECTRA DOES</span>
   <h2 class="section-title">AI Reasoning Across Every<br>Dimension That Matters.</h2>
-  <p class="section-body">SPECTRA sits downstream of your existing scanners — Trivy, Semgrep, Nessus — and applies Claude AI to produce intelligence your team can immediately act on.</p>
+  <p class="section-body">SPECTRA sits downstream of your existing scanners (Trivy, Semgrep, Nessus) and applies Claude AI to produce intelligence your team can immediately act on.</p>
   <div class="features-grid">
     <div class="feature">
       <div class="feature-icon">◈</div>
@@ -490,27 +490,27 @@ footer {
     <div class="feature">
       <div class="feature-icon">⬡</div>
       <div class="feature-title">ATTACK CHAIN ANALYSIS</div>
-      <p class="feature-text">Connects related vulnerabilities into exploitable paths — revealing how an attacker would chain findings your scanner reported as separate, lower-severity issues.</p>
+      <p class="feature-text">Connects related vulnerabilities into exploitable paths, revealing how an attacker would chain findings your scanner reported as separate, lower-severity issues.</p>
     </div>
     <div class="feature">
       <div class="feature-icon">▣</div>
       <div class="feature-title">EXECUTIVE SUMMARIES</div>
-      <p class="feature-text">Leadership-ready briefings generated automatically. No more translating technical findings into business risk language — SPECTRA does it for you.</p>
+      <p class="feature-text">Leadership-ready briefings generated automatically. No more translating technical findings into business risk language yourself. SPECTRA does it for you.</p>
     </div>
     <div class="feature">
       <div class="feature-icon">◎</div>
       <div class="feature-title">ACTIONABLE REMEDIATION</div>
-      <p class="feature-text">Not "patch this CVE" — but how, where, and why. Step-by-step remediation guidance with context specific to your environment and stack.</p>
+      <p class="feature-text">Not just "patch this CVE," but how, where, and why. Step-by-step remediation guidance with context specific to your environment and stack.</p>
     </div>
     <div class="feature">
       <div class="feature-icon">⊞</div>
       <div class="feature-title">SCANNER AGNOSTIC</div>
-      <p class="feature-text">Trivy. Semgrep. Nessus. Any JSON scanner output. SPECTRA plugs into the pipeline you already have — not the one you wish you had.</p>
+      <p class="feature-text">Trivy. Semgrep. Nessus. Any JSON scanner output. SPECTRA plugs into the pipeline you already have, not the one you wish you had.</p>
     </div>
     <div class="feature">
       <div class="feature-icon">◇</div>
       <div class="feature-title">DUAL OUTPUT FORMAT</div>
-      <p class="feature-text">Outputs both Markdown and JSON. Ready for your dashboard, ticketing system, report template, or Slack bot — wherever your team lives.</p>
+      <p class="feature-text">Outputs both Markdown and JSON. Ready for your dashboard, ticketing system, report template, or Slack bot, wherever your team lives.</p>
     </div>
   </div>
 </section>
@@ -564,7 +564,7 @@ footer {
 <section id="docs">
   <span class="section-label">// DOCUMENTATION</span>
   <h2 class="section-title">Everything You Need<br>to Get Running.</h2>
-  <p class="section-body">Full reference documentation — from first install to production CI/CD integration and architecture deep-dives.</p>
+  <p class="section-body">Full reference documentation, from first install to production CI/CD integration and architecture deep-dives.</p>
   <div class="docs-grid">
     <a href="/docs/spectra/installation/" class="docs-card">
       <div class="docs-card-num">01 — SETUP</div>
@@ -635,7 +635,7 @@ footer {
 <section class="cta-section" style="max-width:100%;">
   <div class="cta-glow"></div>
   <h2 class="cta-title">Pick Your Workflow.<br>Ship the Output It Needs.</h2>
-  <p class="cta-sub">Vulnerability management, DevSecOps, red team reporting, or GRC — SPECTRA fits the workflow you already run. Open source, runs in your environment, powered by Claude.</p>
+  <p class="cta-sub">Vulnerability management, DevSecOps, red team reporting, or GRC: SPECTRA fits the workflow you already run. Open source, runs in your environment, powered by Claude.</p>
   <div class="cta-workflows">
     <a href="#usecase-vulnmgmt">VULN MANAGEMENT</a>
     <a href="#usecase-devsecops">DEVSECOPS</a>


### PR DESCRIPTION
## Summary
- Restructure the SPECTRA landing page around four buyer workflows (vuln management, DevSecOps, red team, GRC/compliance)
- Address review findings on the use-case section
- Soften copy tone throughout (hero subhead and remaining sections) to read more like a SaaS startup, replacing heavy em-dash constructions with more natural phrasing

## Test plan
- [ ] Review rendered landing page locally (hugo server) for layout/copy
- [ ] Check responsive layout on mobile widths