### PR TITLE
fix: highlight the S in Security to match other SPECTRA letters

### DIFF
--- a/layouts/_default/spectra-landing.html
+++ b/layouts/_default/spectra-landing.html
@@ -446,7 +446,7 @@ footer {
 <section id="meaning">
   <span class="section-label">// THE NAME</span>
   <h2 class="section-title">What SPECTRA<br>Stands For.</h2>
-  <p class="spectra-phrase">Security <span class="spectra-phrase-accent">P</span>latform for <span class="spectra-phrase-accent">E</span>xpert-level <span class="spectra-phrase-accent">C</span>orrelation, <span class="spectra-phrase-accent">T</span>riage, and <span class="spectra-phrase-accent">R</span>isk <span class="spectra-phrase-accent">A</span>nalysis.</p>
+  <p class="spectra-phrase"><span class="spectra-phrase-accent">S</span>ecurity <span class="spectra-phrase-accent">P</span>latform for <span class="spectra-phrase-accent">E</span>xpert-level <span class="spectra-phrase-accent">C</span>orrelation, <span class="spectra-phrase-accent">T</span>riage, and <span class="spectra-phrase-accent">R</span>isk <span class="spectra-phrase-accent">A</span>nalysis.</p>
   <p class="section-body">AI-powered vulnerability intelligence that turns scanner noise into ranked, actionable findings your team can act on today.</p>
   <div class="spectra-grid">
     <div class="spectra-letter">


### PR DESCRIPTION
## Summary
- Follow-up to #147: the "S" in "Security" was missing the green accent span applied to the other six letters of the SPECTRA backronym, so it didn't stand out from the rest of the phrase.

## Test plan
- [x] `hugo` build succeeds
- [ ] Visual check that all 7 letters are highlighted consistently in the phrase