### PR TITLE
Reorder SPECTRA landing page into a SaaS narrative flow

### DIFF
--- a/layouts/_default/spectra-landing.html
+++ b/layouts/_default/spectra-landing.html
@@ -441,92 +441,6 @@ footer {
   </div>
 </section>
 
-<!-- THE NAME -->
-<div class="band">
-<section id="meaning">
-  <span class="section-label">// THE NAME</span>
-  <h2 class="section-title">What SPECTRA<br>Stands For.</h2>
-  <p class="spectra-phrase"><span class="spectra-phrase-accent">S</span>ecurity <span class="spectra-phrase-accent">P</span>latform for <span class="spectra-phrase-accent">E</span>xpert-level <span class="spectra-phrase-accent">C</span>orrelation, <span class="spectra-phrase-accent">T</span>riage, and <span class="spectra-phrase-accent">R</span>isk <span class="spectra-phrase-accent">A</span>nalysis.</p>
-  <p class="section-body">AI-powered vulnerability intelligence that turns scanner noise into ranked, actionable findings your team can act on today.</p>
-  <div class="spectra-grid">
-    <div class="spectra-letter">
-      <div class="spectra-char">S</div>
-      <div class="spectra-word">SECURITY</div>
-      <p class="spectra-desc">Built for the teams on the front line of vulnerability management, DevSecOps, red teaming, and GRC.</p>
-    </div>
-    <div class="spectra-letter">
-      <div class="spectra-char">P</div>
-      <div class="spectra-word">PLATFORM</div>
-      <p class="spectra-desc">One tool that sits downstream of Trivy, Semgrep, Nessus, Burp Suite, and any JSON scanner output.</p>
-    </div>
-    <div class="spectra-letter">
-      <div class="spectra-char">E</div>
-      <div class="spectra-word">EXPERT-LEVEL</div>
-      <p class="spectra-desc">Reasons about findings the way a senior analyst would, powered by Claude.</p>
-    </div>
-    <div class="spectra-letter">
-      <div class="spectra-char">C</div>
-      <div class="spectra-word">CORRELATION</div>
-      <p class="spectra-desc">Connects related findings into the exploit chains an attacker would actually follow.</p>
-    </div>
-    <div class="spectra-letter">
-      <div class="spectra-char">T</div>
-      <div class="spectra-word">TRIAGE</div>
-      <p class="spectra-desc">Ranks what matters by real-world exploitability, not raw CVSS scores.</p>
-    </div>
-    <div class="spectra-letter">
-      <div class="spectra-char">R</div>
-      <div class="spectra-word">RISK</div>
-      <p class="spectra-desc">Translates technical findings into the business-risk language leadership and auditors expect.</p>
-    </div>
-    <div class="spectra-letter">
-      <div class="spectra-char">A</div>
-      <div class="spectra-word">ANALYSIS</div>
-      <p class="spectra-desc">Produces the prioritized plan, narrative, or report your workflow needs &mdash; not just a score.</p>
-    </div>
-  </div>
-</section>
-</div>
-
-<!-- USE CASES -->
-<div class="band">
-<section id="usecases">
-  <span class="section-label">// WHO IT'S FOR</span>
-  <h2 class="section-title">Built for Four<br>Production Workflows.</h2>
-  <p class="section-body">131 new CVEs land today. Almost none of them matter. SPECTRA decides which ones do, then turns that decision into the artifact each of these workflows actually needs.</p>
-  <div class="usecase-list">
-    <div class="usecase" id="usecase-vulnmgmt">
-      <div class="usecase-icon">◆</div>
-      <span class="usecase-tag">FOR APPSEC &amp; VULN MANAGEMENT TEAMS</span>
-      <div class="usecase-title">VULNERABILITY MANAGEMENT</div>
-      <p class="usecase-desc">Stop drowning in scanner output. SPECTRA ranks what matters, chains what connects, and produces the prioritized remediation plan your team needs, not another spreadsheet of CVEs sorted by CVSS.</p>
-      <a href="/docs/spectra/quickstart/" class="usecase-cta">→ RUN YOUR FIRST ANALYSIS</a>
-    </div>
-    <div class="usecase" id="usecase-devsecops">
-      <div class="usecase-icon">⚙</div>
-      <span class="usecase-tag">FOR PLATFORM &amp; DEVOPS ENGINEERS</span>
-      <div class="usecase-title">DEVSECOPS PIPELINE</div>
-      <p class="usecase-desc">Plug SPECTRA into your CI/CD pipeline and get actionable security context on every build, without flooding developers with noise that kills velocity and trust.</p>
-      <a href="/docs/spectra/cicd-integration/" class="usecase-cta">→ VIEW CI/CD INTEGRATION GUIDE</a>
-    </div>
-    <div class="usecase" id="usecase-redteam">
-      <div class="usecase-icon">⬡</div>
-      <span class="usecase-tag">FOR RED TEAMS &amp; PENTESTERS</span>
-      <div class="usecase-title">RED TEAM REPORTING</div>
-      <p class="usecase-desc">Transform raw engagement findings into chained attack narratives that actually land with leadership. Connect your findings into the story that drives remediation investment.</p>
-      <a href="/docs/spectra/output-formats/#markdown-report-structure" class="usecase-cta">→ SEE ATTACK CHAIN REPORTING</a>
-    </div>
-    <div class="usecase" id="usecase-grc">
-      <div class="usecase-icon">▤</div>
-      <span class="usecase-tag">FOR GRC &amp; COMPLIANCE OFFICERS</span>
-      <div class="usecase-title">GRC &amp; COMPLIANCE REPORTING</div>
-      <p class="usecase-desc">Generate board-ready risk summaries automatically, with technical findings translated into the business-risk language your leadership and auditors expect, without the manual write-up overhead.</p>
-      <a href="/docs/spectra/output-formats/#json-report-structure" class="usecase-cta">→ SEE JSON REPORT STRUCTURE</a>
-    </div>
-  </div>
-</section>
-</div>
-
 <!-- PROBLEM -->
 <div class="band-alt">
 <section id="problem">
@@ -635,6 +549,92 @@ footer {
       </div>
     </div>
   </div>
+</div>
+
+<!-- USE CASES -->
+<div class="band">
+<section id="usecases">
+  <span class="section-label">// WHO IT'S FOR</span>
+  <h2 class="section-title">Built for Four<br>Production Workflows.</h2>
+  <p class="section-body">131 new CVEs land today. Almost none of them matter. SPECTRA decides which ones do, then turns that decision into the artifact each of these workflows actually needs.</p>
+  <div class="usecase-list">
+    <div class="usecase" id="usecase-vulnmgmt">
+      <div class="usecase-icon">◆</div>
+      <span class="usecase-tag">FOR APPSEC &amp; VULN MANAGEMENT TEAMS</span>
+      <div class="usecase-title">VULNERABILITY MANAGEMENT</div>
+      <p class="usecase-desc">Stop drowning in scanner output. SPECTRA ranks what matters, chains what connects, and produces the prioritized remediation plan your team needs, not another spreadsheet of CVEs sorted by CVSS.</p>
+      <a href="/docs/spectra/quickstart/" class="usecase-cta">→ RUN YOUR FIRST ANALYSIS</a>
+    </div>
+    <div class="usecase" id="usecase-devsecops">
+      <div class="usecase-icon">⚙</div>
+      <span class="usecase-tag">FOR PLATFORM &amp; DEVOPS ENGINEERS</span>
+      <div class="usecase-title">DEVSECOPS PIPELINE</div>
+      <p class="usecase-desc">Plug SPECTRA into your CI/CD pipeline and get actionable security context on every build, without flooding developers with noise that kills velocity and trust.</p>
+      <a href="/docs/spectra/cicd-integration/" class="usecase-cta">→ VIEW CI/CD INTEGRATION GUIDE</a>
+    </div>
+    <div class="usecase" id="usecase-redteam">
+      <div class="usecase-icon">⬡</div>
+      <span class="usecase-tag">FOR RED TEAMS &amp; PENTESTERS</span>
+      <div class="usecase-title">RED TEAM REPORTING</div>
+      <p class="usecase-desc">Transform raw engagement findings into chained attack narratives that actually land with leadership. Connect your findings into the story that drives remediation investment.</p>
+      <a href="/docs/spectra/output-formats/#markdown-report-structure" class="usecase-cta">→ SEE ATTACK CHAIN REPORTING</a>
+    </div>
+    <div class="usecase" id="usecase-grc">
+      <div class="usecase-icon">▤</div>
+      <span class="usecase-tag">FOR GRC &amp; COMPLIANCE OFFICERS</span>
+      <div class="usecase-title">GRC &amp; COMPLIANCE REPORTING</div>
+      <p class="usecase-desc">Generate board-ready risk summaries automatically, with technical findings translated into the business-risk language your leadership and auditors expect, without the manual write-up overhead.</p>
+      <a href="/docs/spectra/output-formats/#json-report-structure" class="usecase-cta">→ SEE JSON REPORT STRUCTURE</a>
+    </div>
+  </div>
+</section>
+</div>
+
+<!-- THE NAME -->
+<div class="band-alt">
+<section id="meaning">
+  <span class="section-label">// THE NAME</span>
+  <h2 class="section-title">What SPECTRA<br>Stands For.</h2>
+  <p class="spectra-phrase"><span class="spectra-phrase-accent">S</span>ecurity <span class="spectra-phrase-accent">P</span>latform for <span class="spectra-phrase-accent">E</span>xpert-level <span class="spectra-phrase-accent">C</span>orrelation, <span class="spectra-phrase-accent">T</span>riage, and <span class="spectra-phrase-accent">R</span>isk <span class="spectra-phrase-accent">A</span>nalysis.</p>
+  <p class="section-body">AI-powered vulnerability intelligence that turns scanner noise into ranked, actionable findings your team can act on today.</p>
+  <div class="spectra-grid">
+    <div class="spectra-letter">
+      <div class="spectra-char">S</div>
+      <div class="spectra-word">SECURITY</div>
+      <p class="spectra-desc">Built for the teams on the front line of vulnerability management, DevSecOps, red teaming, and GRC.</p>
+    </div>
+    <div class="spectra-letter">
+      <div class="spectra-char">P</div>
+      <div class="spectra-word">PLATFORM</div>
+      <p class="spectra-desc">One tool that sits downstream of Trivy, Semgrep, Nessus, Burp Suite, and any JSON scanner output.</p>
+    </div>
+    <div class="spectra-letter">
+      <div class="spectra-char">E</div>
+      <div class="spectra-word">EXPERT-LEVEL</div>
+      <p class="spectra-desc">Reasons about findings the way a senior analyst would, powered by Claude.</p>
+    </div>
+    <div class="spectra-letter">
+      <div class="spectra-char">C</div>
+      <div class="spectra-word">CORRELATION</div>
+      <p class="spectra-desc">Connects related findings into the exploit chains an attacker would actually follow.</p>
+    </div>
+    <div class="spectra-letter">
+      <div class="spectra-char">T</div>
+      <div class="spectra-word">TRIAGE</div>
+      <p class="spectra-desc">Ranks what matters by real-world exploitability, not raw CVSS scores.</p>
+    </div>
+    <div class="spectra-letter">
+      <div class="spectra-char">R</div>
+      <div class="spectra-word">RISK</div>
+      <p class="spectra-desc">Translates technical findings into the business-risk language leadership and auditors expect.</p>
+    </div>
+    <div class="spectra-letter">
+      <div class="spectra-char">A</div>
+      <div class="spectra-word">ANALYSIS</div>
+      <p class="spectra-desc">Produces the prioritized plan, narrative, or report your workflow needs &mdash; not just a score.</p>
+    </div>
+  </div>
+</section>
 </div>
 
 <!-- DOCS NAVIGATION -->


### PR DESCRIPTION
## Summary
- Reorders the landing page sections to follow the standard cybersecurity SaaS narrative: **problem -> solution -> demo -> audience -> brand story -> resources -> CTA**
- New order: Hero -> Problem ("CVSS Scores Are Broken") -> Features ("What SPECTRA Does") -> Quick Start terminal demo -> Use Cases ("Built for Four Production Workflows") -> "What SPECTRA Stands For" -> Docs -> Final CTA
- Previously the brand-meaning section ran immediately after the hero (before the problem was even established), and the use-case section preceded the problem/solution sections entirely
- Flips the "What SPECTRA Stands For" section to `band-alt` for visual rhythm now that it follows a plain-background section

## Test plan
- [x] `hugo` build succeeds
- [ ] Visual review of section order, spacing, and nav anchor links (`#usecases`, `#usecase-*`) on `/docs/spectra/`