### PR TITLE
New post: OS Weekly digest for 2026-06-21

### DIFF
--- a/content/posts/os-weekly/images/os-weekly-2026-06-21-hero.svg
+++ b/content/posts/os-weekly/images/os-weekly-2026-06-21-hero.svg
@@ -1,0 +1,103 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#050c1a"/>
+      <stop offset="100%" stop-color="#0c1f3a"/>
+    </linearGradient>
+    <pattern id="grid" width="50" height="50" patternUnits="userSpaceOnUse">
+      <path d="M 50 0 L 0 0 0 50" fill="none" stroke="#0e2440" stroke-width="0.8"/>
+    </pattern>
+    <linearGradient id="cardBg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0c2040"/>
+      <stop offset="100%" stop-color="#071428"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+
+  <!-- Glow -->
+  <ellipse cx="300" cy="315" rx="400" ry="300" fill="#00c9e0" opacity="0.025"/>
+
+  <!-- Top border -->
+  <rect x="0" y="0" width="1200" height="4" fill="#00c9e0"/>
+
+  <!-- Left vertical accent -->
+  <rect x="82" y="118" width="4" height="372" rx="2" fill="#00c9e0"/>
+
+  <!-- OS-WEEKLY label -->
+  <rect x="106" y="118" width="130" height="24" rx="12" fill="#061e38" stroke="#00c9e0" stroke-width="1"/>
+  <text x="171" y="134" text-anchor="middle" font-size="10" fill="#00c9e0" letter-spacing="2" font-weight="600">OS-WEEKLY</text>
+  <text x="246" y="134" font-size="11" fill="#3d6b8c" letter-spacing="1">JUNE 21, 2026</text>
+
+  <!-- Title -->
+  <text x="106" y="208" font-size="42" font-weight="800" fill="#e8f4ff" letter-spacing="-1">Patch Deadlines,</text>
+  <text x="106" y="258" font-size="42" font-weight="800" fill="#e8f4ff" letter-spacing="-1">a Note-Free Ransomware,</text>
+  <text x="106" y="308" font-size="42" font-weight="800" fill="#00c9e0" letter-spacing="-1">and AI Reshaping Teams</text>
+
+  <!-- Divider -->
+  <rect x="106" y="332" width="420" height="2" rx="1" fill="#1a3a5a"/>
+
+  <!-- Subtitle -->
+  <text x="106" y="365" font-size="18" fill="#7aaece" letter-spacing="0.3">This week's must-know cybersecurity stories</text>
+
+  <!-- Tags -->
+  <rect x="106" y="392" width="116" height="26" rx="13" fill="#051828" stroke="#ef4444" stroke-width="1"/>
+  <text x="164" y="409" text-anchor="middle" font-size="11" fill="#ef4444" letter-spacing="0.5">CVE Deadlines</text>
+
+  <rect x="232" y="392" width="112" height="26" rx="13" fill="#051828" stroke="#f59e0b" stroke-width="1"/>
+  <text x="288" y="409" text-anchor="middle" font-size="11" fill="#f59e0b" letter-spacing="0.5">Ransomware</text>
+
+  <rect x="354" y="392" width="148" height="26" rx="13" fill="#051828" stroke="#10b981" stroke-width="1"/>
+  <text x="428" y="409" text-anchor="middle" font-size="11" fill="#10b981" letter-spacing="0.5">AI &amp; Security Teams</text>
+
+  <!-- Branding -->
+  <text x="106" y="572" font-size="12" fill="#2a5678" letter-spacing="3">CYBERSECURITYOS.NET</text>
+  <text x="106" y="591" font-size="11" fill="#1e3d56">CyberShield Weekly Digest</text>
+
+  <!-- RIGHT: Headline ticker -->
+  <rect x="690" y="72" width="462" height="506" rx="14" fill="url(#cardBg)" stroke="#132d4d" stroke-width="1.5"/>
+
+  <!-- Dashboard header -->
+  <rect x="690" y="72" width="462" height="50" rx="14" fill="#071428"/>
+  <rect x="690" y="108" width="462" height="14" fill="#071428"/>
+  <circle cx="718" cy="97" r="6" fill="#ef4444" opacity="0.6"/>
+  <circle cx="738" cy="97" r="6" fill="#f59e0b" opacity="0.6"/>
+  <circle cx="758" cy="97" r="6" fill="#10b981" opacity="0.6"/>
+  <text x="921" y="102" text-anchor="middle" font-size="10" fill="#3d6b8c" letter-spacing="1.5">THIS WEEK'S HEADLINES</text>
+
+  <!-- Headline 1: Joomla -->
+  <rect x="710" y="138" width="422" height="78" rx="7" fill="#071528" stroke="#ef4444" stroke-width="1"/>
+  <rect x="710" y="138" width="4" height="78" fill="#ef4444"/>
+  <text x="726" y="158" font-size="9" fill="#ef4444" letter-spacing="1.2" font-weight="700">MAX SEVERITY · CISA DEADLINE</text>
+  <text x="726" y="178" font-size="14" fill="#e8f4ff" font-weight="600">Joomla JCE Plugin Flaw — Patch by Friday</text>
+  <text x="726" y="198" font-size="10.5" fill="#5a8aa8">Actively exploited; federal agencies under directive</text>
+
+  <!-- Headline 2: Splunk -->
+  <rect x="710" y="226" width="422" height="78" rx="7" fill="#071528" stroke="#ef4444" stroke-width="1"/>
+  <rect x="710" y="226" width="4" height="78" fill="#ef4444"/>
+  <text x="726" y="246" font-size="9" fill="#ef4444" letter-spacing="1.2" font-weight="700">CVE-2026-20253 · CVSS 9.8</text>
+  <text x="726" y="266" font-size="14" fill="#e8f4ff" font-weight="600">Splunk Unauthenticated RCE</text>
+  <text x="726" y="286" font-size="10.5" fill="#5a8aa8">Below 10.2.4 / 10.0.7 affected — patch now</text>
+
+  <!-- Headline 3: Prinz Eugen -->
+  <rect x="710" y="314" width="422" height="78" rx="7" fill="#071528" stroke="#f59e0b" stroke-width="1"/>
+  <rect x="710" y="314" width="4" height="78" fill="#f59e0b"/>
+  <text x="726" y="334" font-size="9" fill="#f59e0b" letter-spacing="1.2" font-weight="700">NEW RANSOMWARE STRAIN</text>
+  <text x="726" y="354" font-size="14" fill="#e8f4ff" font-weight="600">"Prinz Eugen" Skips the Ransom Note</text>
+  <text x="726" y="374" font-size="10.5" fill="#5a8aa8">Prioritizes recently modified files first</text>
+
+  <!-- Headline 4: AI staffing -->
+  <rect x="710" y="402" width="422" height="78" rx="7" fill="#071528" stroke="#10b981" stroke-width="1"/>
+  <rect x="710" y="402" width="4" height="78" fill="#10b981"/>
+  <text x="726" y="422" font-size="9" fill="#10b981" letter-spacing="1.2" font-weight="700">WORKFORCE TRENDS</text>
+  <text x="726" y="442" font-size="14" fill="#e8f4ff" font-weight="600">AI Pushes Teams Toward Fractional CISOs</text>
+  <text x="726" y="462" font-size="10.5" fill="#5a8aa8">A growing entry point for new practitioners</text>
+
+  <!-- Footer bar -->
+  <rect x="710" y="490" width="422" height="70" rx="7" fill="#04101e"/>
+  <text x="722" y="510" font-size="8.5" fill="#3d6b8c" letter-spacing="1.5">ALSO IN THIS ISSUE</text>
+  <text x="722" y="528" font-size="10.5" fill="#4a7fa0">Gravity SMTP key leak · Popa botnet ties to NetNut</text>
+  <text x="722" y="544" font-size="10.5" fill="#4a7fa0">Top 10 attack surface exposures · Phishing-test backlash</text>
+</svg>

--- a/content/posts/os-weekly/images/os-weekly-2026-06-21-thumb.svg
+++ b/content/posts/os-weekly/images/os-weekly-2026-06-21-thumb.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 420" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#050c1a"/>
+      <stop offset="100%" stop-color="#0c1f3a"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#0e2440" stroke-width="0.7"/>
+    </pattern>
+  </defs>
+
+  <rect width="800" height="420" fill="url(#bg)"/>
+  <rect width="800" height="420" fill="url(#grid)"/>
+
+  <!-- Top accent -->
+  <rect x="0" y="0" width="800" height="4" fill="#00c9e0"/>
+
+  <!-- Left bar -->
+  <rect x="52" y="62" width="4" height="248" rx="2" fill="#00c9e0"/>
+
+  <!-- OS-WEEKLY chip -->
+  <rect x="72" y="62" width="106" height="22" rx="11" fill="#061e38" stroke="#00c9e0" stroke-width="1"/>
+  <text x="125" y="77" text-anchor="middle" font-size="9.5" fill="#00c9e0" letter-spacing="2" font-weight="600">OS-WEEKLY</text>
+  <text x="188" y="77" font-size="9.5" fill="#3d6b8c" letter-spacing="1">JUN 21, 2026</text>
+
+  <!-- Title -->
+  <text x="72" y="138" font-size="32" font-weight="800" fill="#e8f4ff" letter-spacing="-1">Patch Deadlines</text>
+  <text x="72" y="178" font-size="32" font-weight="800" fill="#00c9e0" letter-spacing="-1">&amp; a Note-Free</text>
+  <text x="72" y="218" font-size="32" font-weight="800" fill="#00c9e0" letter-spacing="-1">Ransomware</text>
+
+  <!-- Divider -->
+  <rect x="72" y="234" width="280" height="2" rx="1" fill="#1a3a5a"/>
+
+  <!-- Subtitle -->
+  <text x="72" y="262" font-size="14.5" fill="#7aaece">Plus: AI reshaping security teams</text>
+
+  <!-- Tags -->
+  <rect x="72" y="284" width="92" height="22" rx="11" fill="#051828" stroke="#ef4444" stroke-width="1"/>
+  <text x="118" y="299" text-anchor="middle" font-size="10" fill="#ef4444">Max Severity</text>
+
+  <rect x="172" y="284" width="98" height="22" rx="11" fill="#051828" stroke="#f59e0b" stroke-width="1"/>
+  <text x="221" y="299" text-anchor="middle" font-size="10" fill="#f59e0b">Ransomware</text>
+
+  <!-- Branding -->
+  <text x="72" y="388" font-size="11" fill="#1e3d56" letter-spacing="2.5">CYBERSECURITYOS.NET</text>
+
+  <!-- Right: alert cards -->
+  <rect x="480" y="64" width="248" height="68" rx="7" fill="#071528" stroke="#ef4444" stroke-width="1"/>
+  <rect x="480" y="64" width="4" height="68" fill="#ef4444"/>
+  <text x="494" y="82" font-size="8" fill="#ef4444" letter-spacing="1" font-weight="700">CVSS 9.8 · UNAUTH RCE</text>
+  <text x="494" y="100" font-size="12.5" fill="#f0f6ff" font-weight="600">Splunk Enterprise</text>
+  <text x="494" y="118" font-size="9.5" fill="#5a8aa8">Patch below 10.2.4 / 10.0.7</text>
+
+  <rect x="480" y="142" width="248" height="68" rx="7" fill="#071528" stroke="#ef4444" stroke-width="1"/>
+  <rect x="480" y="142" width="4" height="68" fill="#ef4444"/>
+  <text x="494" y="160" font-size="8" fill="#ef4444" letter-spacing="1" font-weight="700">CISA DEADLINE · FRIDAY</text>
+  <text x="494" y="178" font-size="12.5" fill="#f0f6ff" font-weight="600">Joomla JCE Plugin</text>
+  <text x="494" y="196" font-size="9.5" fill="#5a8aa8">Actively exploited in the wild</text>
+
+  <rect x="480" y="220" width="248" height="68" rx="7" fill="#071528" stroke="#f59e0b" stroke-width="1"/>
+  <rect x="480" y="220" width="4" height="68" fill="#f59e0b"/>
+  <text x="494" y="238" font-size="8" fill="#f59e0b" letter-spacing="1" font-weight="700">NEW STRAIN · NO RANSOM NOTE</text>
+  <text x="494" y="256" font-size="12.5" fill="#f0f6ff" font-weight="600">Prinz Eugen Ransomware</text>
+  <text x="494" y="274" font-size="9.5" fill="#5a8aa8">Targets recently modified files</text>
+
+  <rect x="480" y="298" width="248" height="68" rx="7" fill="#031410" stroke="#10b981" stroke-width="1"/>
+  <text x="494" y="317" font-size="8" fill="#6ee7b7" letter-spacing="1.2">WORKFORCE TREND</text>
+  <text x="494" y="335" font-size="12" fill="#f0f6ff" font-weight="600">AI Drives Fractional CISO Roles</text>
+  <text x="494" y="353" font-size="9.5" fill="#4a7fa0">A new on-ramp for entry-level talent</text>
+</svg>

--- a/content/posts/os-weekly/os-weekly-2026-06-21.md
+++ b/content/posts/os-weekly/os-weekly-2026-06-21.md
@@ -1,0 +1,90 @@
+---
+title: "OS Weekly: Patch Deadlines, a Note-Free Ransomware, and AI Reshaping Security Teams"
+date: 2026-06-21
+draft: false
+author: "Michael Tayo"
+tags: ["CybersecurityOS", "Cybersecurity", "Weekly Digest", "OS Weekly", "Ransomware", "Vulnerability Management", "AI and Security"]
+categories: ["OS Weekly", "Threat Intelligence"]
+description: "This week: maximum-severity flaws in Joomla and Splunk get urgent patch deadlines, a new ransomware strain skips the ransom note, and AI keeps reshaping how security teams are staffed."
+slug: "os-weekly-2026-06-21"
+show_reading_time: true
+images:
+    - /posts/os-weekly/images/os-weekly-2026-06-21-hero.svg
+featured_image: /posts/os-weekly/images/os-weekly-2026-06-21-thumb.svg
+---
+
+This week brought two maximum-severity vulnerabilities with hard patch deadlines, a ransomware operator that changed the playbook on victim communication, and fresh evidence that AI is reshaping how security teams are built and staffed. Here's everything cybersecurity professionals and aspiring practitioners need to know from the past seven days.
+
+![OS Weekly: Patch Deadlines, a Note-Free Ransomware, and AI Reshaping Security Teams](/posts/os-weekly/images/os-weekly-2026-06-21-hero.svg)
+
+## CISA Orders Feds to Patch a Max-Severity Joomla Plugin Flaw by Friday
+
+The U.S. Cybersecurity and Infrastructure Security Agency issued a directive requiring federal agencies to patch a maximum-severity vulnerability in the Widget Factory Joomla Content Editor (JCE) plugin by this Friday. The flaw is being actively exploited in real-world attacks, which is what triggered the compressed timeline rather than the standard patch cycle.
+
+For practitioners, this is a useful case study in how CISA's Known Exploited Vulnerabilities process works: a directive with a hard deadline signals confirmed, active exploitation — not a theoretical risk. If you administer Joomla sites with the JCE plugin, treat this as immediate-action, not backlog.
+
+**Read more:** [CISA orders feds to patch max severity Joomla plugin flaw by Friday](https://www.bleepingcomputer.com/news/security/cisa-orders-feds-to-patch-max-severity-joomla-plugin-flaw-by-friday/)
+
+## Critical Splunk Enterprise Flaw Lets Attackers Run Code Without Authentication
+
+Splunk shipped fixes for CVE-2026-20253, a critical vulnerability carrying a CVSS score of 9.8. The flaw allows unauthenticated attackers to perform arbitrary file operations, with a credible path to remote code execution. Versions below 10.2.4 and 10.0.7 are affected.
+
+This one deserves extra attention because of where Splunk sits in the stack: it's the platform many SOCs rely on for detection and logging. An unauthenticated RCE in your detection tooling is a worst-case scenario — it threatens both the environment you're protecting and your visibility into the attack itself. Confirm your version, patch now, and review logs for anomalous activity predating the patch.
+
+**Read more:** [Critical Splunk Enterprise Flaw Lets Attackers Run Code Without Authentication](https://thehackernews.com/2026/06/critical-splunk-enterprise-flaw-lets.html)
+
+## Hackers Exploit Gravity SMTP WordPress Plugin Bug to Expose API Keys
+
+Threat actors are actively exploiting CVE-2026-4020, a medium-severity (CVSS 5.3) information-disclosure vulnerability in the Gravity SMTP plugin, installed on roughly 100,000 WordPress sites. Unauthenticated attackers can extract configuration data, API keys, secrets, and OAuth tokens — even though the flaw has already been patched upstream.
+
+The CVSS score undersells the real-world risk here. A "medium severity" information leak that hands over API keys and OAuth tokens is a credential-theft vulnerability in disguise, and those credentials get chained into far more damaging follow-on attacks. If you run WordPress sites with Gravity SMTP, verify you're on the patched version immediately and rotate any credentials that may have been exposed.
+
+**Read more:** [Hackers Exploit Gravity SMTP WordPress Plugin Bug to Expose API Keys](https://thehackernews.com/2026/06/hackers-exploit-gravity-smtp-wordpress.html)
+
+## New "Prinz Eugen" Ransomware Prioritizes Recent Files for Encryption
+
+A newly identified ransomware operation called Prinz Eugen introduces two notable changes to the usual playbook: it prioritizes encrypting the most recently modified files on a victim's system, and it leaves no ransom note at all.
+
+Targeting recent files maximizes disruption to active work — the files someone was using yesterday are the ones most likely to be irreplaceable without a fresh backup. The absence of a ransom note is arguably the more interesting design choice: it strips victims of a clear path to understanding what happened or how to respond, complicating incident response and making early detection (through file-modification monitoring and endpoint protection) the primary line of defense rather than negotiation.
+
+**Read more:** [New Prinz Eugen ransomware prioritizes recent files for encryption](https://www.bleepingcomputer.com/news/security/new-prinz-eugen-ransomware-prioritizes-recent-files-for-encryption/)
+
+## 'Popa' Botnet Linked to a Publicly-Traded Israeli Firm
+
+Krebs on Security traced the Popa botnet — an Android-based network that has compromised millions of consumer TV boxes over the past four years to run ad fraud, account takeovers, and large-scale data scraping — back to NetNut, a residential proxy service operated by Alarum Technologies Ltd, a company listed on NASDAQ under the ticker ALAR.
+
+The story is a reminder that botnet infrastructure doesn't always live in obviously criminal corners of the internet. Residential proxy services occupy a gray zone between legitimate business and traffic laundering for malicious actors, and the IoT devices being hijacked — consumer TV boxes — remain chronically under-secured and rarely monitored by their owners.
+
+**Read more:** ['Popa' Botnet Linked to Publicly-Traded Israeli Firm](https://krebsonsecurity.com/2026/06/popa-botnet-linked-to-publicly-traded-israeli-firm/)
+
+## The Top 10 Attack Surface Exposures Heading Into 2026
+
+A new roundup of the top attack surface exposures for 2026 makes a point worth repeating: most breaches still start with exposed admin panels vulnerable to brute force, or with reused credentials from prior breaches — not zero-days. That said, the report also flags "MongoBleed," a vulnerability that let attackers extract credentials and session tokens from server memory without authentication, as a reminder that when a genuine zero-day does surface, the window between disclosure and mass exploitation keeps shrinking.
+
+For teams setting security priorities, this is a useful gut check: the highest-leverage work is often unglamorous — locking down exposed admin interfaces and eliminating credential reuse — rather than chasing the next headline CVE.
+
+**Read more:** [The Top 10 Attack Surface Exposures in 2026](https://thehackernews.com/2026/06/the-top-10-attack-surface-exposures-in.html)
+
+## Stressors and AI Are Forcing Changes to Cybersecurity Teams
+
+Dark Reading reports that the combination of an expanding threat landscape and AI-driven complexity is making the CISO role harder than it's ever been — and pushing more organizations to bring in cybersecurity expertise on a part-time or fractional basis rather than committing to full-time hires.
+
+This trend matters most for people trying to break into the field. Fractional and contract security work is becoming a legitimate entry point rather than a stopgap, giving newer practitioners a way to build experience across multiple environments before landing a full-time role. It also signals that organizations are looking for adaptable, AI-literate security generalists rather than narrow specialists.
+
+**Read more:** [Stressors, AI Forcing Changes to Cybersecurity Teams](https://www.darkreading.com/cybersecurity-operations/stressors-ai-changes-cybersecurity-teams)
+
+## A "Day Off" Email That Was Actually a Phishing Test
+
+Healthcare workers at Newfoundland and Labrador Health Services received an email promising an unexpected day off — only to learn afterward that it was a simulated phishing exercise designed to test their awareness.
+
+It's a sharp illustration of how effective social engineering works: it exploits hope, routine, and the desire for good news, not just fear or urgency. For security awareness programs, the lesson cuts both ways — phishing simulations that mirror real attacker psychology are more effective precisely because they're uncomfortable, but organizations also need to manage the trust and morale cost of catching employees off guard, especially in high-stress sectors like healthcare.
+
+**Read more:** [Healthcare workers emailed about a day off — but it was a cybersecurity test](https://www.cbc.ca/news/canada/newfoundland-labrador/nlhs-phishing-email-9.7238374)
+
+---
+
+> 💡 **Want to lead with clarity in the AI era?**
+> If you're aiming to lead a security team, break into cybersecurity, or operate with greater speed and confidence, this is the toolkit you've been missing:
+> 🔗 [Cybersecurity Leadership OS: Battle-Tested Mental Models for Clarity, Speed & Command](https://store.cybersecurityos.net/l/cybersecurity-leadership-os)
+
+That's the week. Every patch deadline and every new ransomware variant is also a free study guide — pull the CVE, read the advisory, trace the attack chain. Follow CyberShield for the weekly rundown and keep building the habits that separate the professionals who react from the ones who anticipate.


### PR DESCRIPTION
## Summary
- Adds the first OS Weekly roundup: Joomla/Splunk patch deadlines, the note-free Prinz Eugen ransomware, the Gravity SMTP key leak, the Popa botnet/NetNut tie, and AI-driven shifts toward fractional CISO roles.
- New hero and thumbnail SVGs in the existing OS-Weekly dashboard visual style for `featured_image`/social card and in-post banner.

## Test plan
- [x] `hugo --gc --minify` builds cleanly with the new post and renders at `/posts/os-weekly/os-weekly-2026-06-21/`
- [ ] Spot-check the rendered post and images in a preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)