### PR TITLE
chore: update deploy actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Index site with Pagefind
         run: npx pagefind --source public
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./public
 
@@ -79,4 +79,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Problem

The last deploy run logged:

> Node 20 is being deprecated. This workflow is running with Node 24 by default.

`upload-pages-artifact@v3` and `deploy-pages@v4` are built on Node 20. GitHub Actions deprecated Node 20 in September 2025 and now defaults to Node 24. The warning will become a hard failure once Node 20 support is fully removed.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/upload-pages-artifact` | v3 (Node 20) | v4 (Node 20+/24) |
| `actions/deploy-pages` | v4 (Node 20) | v5 (Node 20+/24) |

All other actions (`checkout@v4`, `configure-pages@v5`) are already current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)