### PR TITLE
Enable claude-plugins marketplace (dev-workflow, content-ops)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "extraKnownMarketplaces": {
+    "claude-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "d0uble3L/claude-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "content-ops@claude-plugins": true,
+    "dev-workflow@claude-plugins": true
+  }
+}


### PR DESCRIPTION
## Summary
- Registers the `d0uble3L/claude-plugins` marketplace via `.claude/settings.json`
- Enables `dev-workflow` (pr-ship skill) and `content-ops` (hugo-content-ship skill)

## Test plan
- [ ] Open the repo in Claude Code, trust it, confirm the marketplace install prompt appears
- [ ] Run `/plugin list --enabled` and confirm both plugins show up