### PR TITLE
Fix marketplace name after rename

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,14 +1,14 @@
 {
+  "enabledPlugins": {
+    "content-ops@d0uble3l-plugins": true,
+    "dev-workflow@d0uble3l-plugins": true
+  },
   "extraKnownMarketplaces": {
-    "claude-plugins": {
+    "d0uble3l-plugins": {
       "source": {
         "source": "github",
         "repo": "d0uble3L/claude-plugins"
       }
     }
-  },
-  "enabledPlugins": {
-    "content-ops@claude-plugins": true,
-    "dev-workflow@claude-plugins": true
   }
 }


### PR DESCRIPTION
Marketplace source repo renamed its marketplace.json name field from claude-plugins to d0uble3l-plugins (Claude Code rejected the old name as impersonating an official marketplace). Updates the local alias to match.