### PR TITLE
fix: add missing banner SVGs to os-weekly-2026-07-12

### DIFF
--- a/content/posts/os-weekly/images/os-weekly-2026-07-12-hero.svg
+++ b/content/posts/os-weekly/images/os-weekly-2026-07-12-hero.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 420" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#050c1a"/>
+      <stop offset="100%" stop-color="#0c1f3a"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#0e2440" stroke-width="0.7"/>
+    </pattern>
+  </defs>
+
+  <rect width="1200" height="420" fill="url(#bg)"/>
+  <rect width="1200" height="420" fill="url(#grid)"/>
+
+  <!-- Top accent -->
+  <rect x="0" y="0" width="1200" height="4" fill="#00c9e0"/>
+
+  <!-- Left bar -->
+  <rect x="64" y="56" width="4" height="280" rx="2" fill="#00c9e0"/>
+
+  <!-- OS-WEEKLY chip -->
+  <rect x="84" y="56" width="106" height="22" rx="11" fill="#061e38" stroke="#00c9e0" stroke-width="1"/>
+  <text x="137" y="71" text-anchor="middle" font-size="9.5" fill="#00c9e0" letter-spacing="2" font-weight="600">OS-WEEKLY</text>
+  <text x="200" y="71" font-size="9.5" fill="#3d6b8c" letter-spacing="1">JUL 12, 2026</text>
+
+  <!-- Title -->
+  <text x="84" y="136" font-size="32" font-weight="800" fill="#e8f4ff" letter-spacing="-0.5">Poisoned npm &amp; CISA's</text>
+  <text x="84" y="182" font-size="32" font-weight="800" fill="#00c9e0" letter-spacing="-0.5">Patch Deadline &amp; AI's Double Edge</text>
+
+  <!-- Divider -->
+  <rect x="84" y="204" width="380" height="2" rx="1" fill="#1a3a5a"/>
+
+  <!-- Subtitle -->
+  <text x="84" y="234" font-size="15" fill="#7aaece">Six minutes from publish to flagged. Supply chain trust is still the softest target.</text>
+
+  <!-- Tags -->
+  <rect x="84" y="260" width="100" height="24" rx="12" fill="#051828" stroke="#f59e0b" stroke-width="1"/>
+  <text x="134" y="276" text-anchor="middle" font-size="10.5" fill="#f59e0b">Supply Chain</text>
+
+  <rect x="192" y="260" width="56" height="24" rx="12" fill="#051828" stroke="#ef4444" stroke-width="1"/>
+  <text x="220" y="276" text-anchor="middle" font-size="10.5" fill="#ef4444">CISA</text>
+
+  <rect x="256" y="260" width="80" height="24" rx="12" fill="#051828" stroke="#a855f7" stroke-width="1"/>
+  <text x="296" y="276" text-anchor="middle" font-size="10.5" fill="#a855f7">Extortion</text>
+
+  <rect x="344" y="260" width="106" height="24" rx="12" fill="#051828" stroke="#10b981" stroke-width="1"/>
+  <text x="397" y="276" text-anchor="middle" font-size="10.5" fill="#10b981">AI and Security</text>
+
+  <!-- Branding -->
+  <text x="84" y="388" font-size="11" fill="#1e3d56" letter-spacing="2.5">CYBERSECURITYOS.NET</text>
+
+  <!-- Right: story cards (two columns) -->
+  <!-- Col 1 -->
+  <rect x="680" y="58" width="230" height="78" rx="7" fill="#071528" stroke="#f59e0b" stroke-width="1"/>
+  <rect x="680" y="58" width="4" height="78" fill="#f59e0b"/>
+  <text x="694" y="79" font-size="8" fill="#f59e0b" letter-spacing="1" font-weight="700">SUPPLY CHAIN · NPM</text>
+  <text x="694" y="97" font-size="12.5" fill="#f0f6ff" font-weight="600">jscrambler 8.14.0</text>
+  <text x="694" y="117" font-size="9.5" fill="#5a8aa8">Rust infostealer, preinstall hook</text>
+
+  <rect x="680" y="148" width="230" height="78" rx="7" fill="#071528" stroke="#ef4444" stroke-width="1"/>
+  <rect x="680" y="148" width="4" height="78" fill="#ef4444"/>
+  <text x="694" y="169" font-size="8" fill="#ef4444" letter-spacing="1" font-weight="700">CISA MANDATE</text>
+  <text x="694" y="187" font-size="12.5" fill="#f0f6ff" font-weight="600">Langflow Auth Bypass</text>
+  <text x="694" y="207" font-size="9.5" fill="#5a8aa8">Active exploitation confirmed</text>
+
+  <rect x="680" y="238" width="230" height="78" rx="7" fill="#071528" stroke="#3b82f6" stroke-width="1"/>
+  <rect x="680" y="238" width="4" height="78" fill="#3b82f6"/>
+  <text x="694" y="259" font-size="8" fill="#3b82f6" letter-spacing="1" font-weight="700">FBI SEIZURE</text>
+  <text x="694" y="277" font-size="12.5" fill="#f0f6ff" font-weight="600">NetNut / Popa Botnet</text>
+  <text x="694" y="297" font-size="9.5" fill="#5a8aa8">2M devices, NASDAQ-listed firm</text>
+
+  <rect x="680" y="328" width="230" height="70" rx="7" fill="#071528" stroke="#a855f7" stroke-width="1"/>
+  <rect x="680" y="328" width="4" height="70" fill="#a855f7"/>
+  <text x="694" y="347" font-size="8" fill="#a855f7" letter-spacing="1" font-weight="700">EXTORTION</text>
+  <text x="694" y="365" font-size="12.5" fill="#f0f6ff" font-weight="600">Kairos / $1M · No Ransomware</text>
+  <text x="694" y="385" font-size="9.5" fill="#5a8aa8">Exposure threat was leverage enough</text>
+
+  <!-- Col 2 -->
+  <rect x="924" y="58" width="230" height="78" rx="7" fill="#071528" stroke="#10b981" stroke-width="1"/>
+  <rect x="924" y="58" width="4" height="78" fill="#10b981"/>
+  <text x="938" y="79" font-size="8" fill="#10b981" letter-spacing="1" font-weight="700">AI AND SECURITY</text>
+  <text x="938" y="97" font-size="12.5" fill="#f0f6ff" font-weight="600">The Asymmetric Future</text>
+  <text x="938" y="117" font-size="9.5" fill="#5a8aa8">Both sides now have AI</text>
+
+  <rect x="924" y="148" width="230" height="78" rx="7" fill="#071528" stroke="#00c9e0" stroke-width="1"/>
+  <rect x="924" y="148" width="4" height="78" fill="#00c9e0"/>
+  <text x="938" y="169" font-size="8" fill="#00c9e0" letter-spacing="1" font-weight="700">EU POLICY</text>
+  <text x="938" y="187" font-size="12.5" fill="#f0f6ff" font-weight="600">EU AI + Cybersecurity Plan</text>
+  <text x="938" y="207" font-size="9.5" fill="#5a8aa8">Regulatory framework by 2026</text>
+
+  <rect x="924" y="238" width="230" height="78" rx="7" fill="#071528" stroke="#f59e0b" stroke-width="1"/>
+  <rect x="924" y="238" width="4" height="78" fill="#f59e0b"/>
+  <text x="938" y="259" font-size="8" fill="#f59e0b" letter-spacing="1" font-weight="700">THREAT INTEL · APT</text>
+  <text x="938" y="277" font-size="12.5" fill="#f0f6ff" font-weight="600">UAT-7810 / LONGLEASH</text>
+  <text x="938" y="297" font-size="9.5" fill="#5a8aa8">China-linked ORB expansion</text>
+
+  <rect x="924" y="328" width="230" height="70" rx="7" fill="#071528" stroke="#64748b" stroke-width="1"/>
+  <rect x="924" y="328" width="4" height="70" fill="#64748b"/>
+  <text x="938" y="347" font-size="8" fill="#64748b" letter-spacing="1" font-weight="700">INDUSTRY</text>
+  <text x="938" y="365" font-size="12.5" fill="#f0f6ff" font-weight="600">Jen Ellis Named MBE</text>
+  <text x="938" y="385" font-size="9.5" fill="#5a8aa8">Research &amp; policy advocacy honored</text>
+</svg>

--- a/content/posts/os-weekly/images/os-weekly-2026-07-12-thumb.svg
+++ b/content/posts/os-weekly/images/os-weekly-2026-07-12-thumb.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 420" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#050c1a"/>
+      <stop offset="100%" stop-color="#0c1f3a"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#0e2440" stroke-width="0.7"/>
+    </pattern>
+  </defs>
+
+  <rect width="800" height="420" fill="url(#bg)"/>
+  <rect width="800" height="420" fill="url(#grid)"/>
+
+  <!-- Top accent -->
+  <rect x="0" y="0" width="800" height="4" fill="#00c9e0"/>
+
+  <!-- Left bar -->
+  <rect x="52" y="56" width="4" height="254" rx="2" fill="#00c9e0"/>
+
+  <!-- OS-WEEKLY chip -->
+  <rect x="72" y="56" width="106" height="22" rx="11" fill="#061e38" stroke="#00c9e0" stroke-width="1"/>
+  <text x="125" y="71" text-anchor="middle" font-size="9.5" fill="#00c9e0" letter-spacing="2" font-weight="600">OS-WEEKLY</text>
+  <text x="188" y="71" font-size="9.5" fill="#3d6b8c" letter-spacing="1">JUL 12, 2026</text>
+
+  <!-- Title -->
+  <text x="72" y="128" font-size="26" font-weight="800" fill="#e8f4ff" letter-spacing="-0.5">Poisoned npm &amp;</text>
+  <text x="72" y="166" font-size="26" font-weight="800" fill="#e8f4ff" letter-spacing="-0.5">CISA's Patch Deadline</text>
+  <text x="72" y="204" font-size="26" font-weight="800" fill="#00c9e0" letter-spacing="-0.5">&amp; AI's Double Edge</text>
+
+  <!-- Divider -->
+  <rect x="72" y="222" width="280" height="2" rx="1" fill="#1a3a5a"/>
+
+  <!-- Subtitle -->
+  <text x="72" y="250" font-size="14" fill="#7aaece">6 min to detect. Seconds to infect.</text>
+
+  <!-- Tags -->
+  <rect x="72" y="272" width="100" height="22" rx="11" fill="#051828" stroke="#f59e0b" stroke-width="1"/>
+  <text x="122" y="287" text-anchor="middle" font-size="10" fill="#f59e0b">Supply Chain</text>
+
+  <rect x="180" y="272" width="56" height="22" rx="11" fill="#051828" stroke="#ef4444" stroke-width="1"/>
+  <text x="208" y="287" text-anchor="middle" font-size="10" fill="#ef4444">CISA</text>
+
+  <rect x="244" y="272" width="106" height="22" rx="11" fill="#051828" stroke="#10b981" stroke-width="1"/>
+  <text x="297" y="287" text-anchor="middle" font-size="10" fill="#10b981">AI and Security</text>
+
+  <!-- Branding -->
+  <text x="72" y="388" font-size="11" fill="#1e3d56" letter-spacing="2.5">CYBERSECURITYOS.NET</text>
+
+  <!-- Right: story cards -->
+  <rect x="476" y="58" width="256" height="70" rx="7" fill="#071528" stroke="#f59e0b" stroke-width="1"/>
+  <rect x="476" y="58" width="4" height="70" fill="#f59e0b"/>
+  <text x="490" y="77" font-size="8" fill="#f59e0b" letter-spacing="1" font-weight="700">SUPPLY CHAIN · NPM</text>
+  <text x="490" y="95" font-size="12.5" fill="#f0f6ff" font-weight="600">jscrambler 8.14.0</text>
+  <text x="490" y="115" font-size="9.5" fill="#5a8aa8">Rust infostealer in preinstall hook</text>
+
+  <rect x="476" y="138" width="256" height="70" rx="7" fill="#071528" stroke="#ef4444" stroke-width="1"/>
+  <rect x="476" y="138" width="4" height="70" fill="#ef4444"/>
+  <text x="490" y="157" font-size="8" fill="#ef4444" letter-spacing="1" font-weight="700">CISA PATCH MANDATE</text>
+  <text x="490" y="175" font-size="12.5" fill="#f0f6ff" font-weight="600">Langflow Auth Bypass</text>
+  <text x="490" y="195" font-size="9.5" fill="#5a8aa8">Actively exploited in the wild</text>
+
+  <rect x="476" y="218" width="256" height="70" rx="7" fill="#071528" stroke="#a855f7" stroke-width="1"/>
+  <rect x="476" y="218" width="4" height="70" fill="#a855f7"/>
+  <text x="490" y="237" font-size="8" fill="#a855f7" letter-spacing="1" font-weight="700">EXTORTION · NO RANSOMWARE</text>
+  <text x="490" y="255" font-size="12.5" fill="#f0f6ff" font-weight="600">Kairos / $1M Gov Payout</text>
+  <text x="490" y="275" font-size="9.5" fill="#5a8aa8">Exposure threat was enough</text>
+
+  <rect x="476" y="298" width="256" height="70" rx="7" fill="#071528" stroke="#10b981" stroke-width="1"/>
+  <rect x="476" y="298" width="4" height="70" fill="#10b981"/>
+  <text x="490" y="317" font-size="8" fill="#10b981" letter-spacing="1" font-weight="700">AI AND SECURITY</text>
+  <text x="490" y="335" font-size="12.5" fill="#f0f6ff" font-weight="600">The Asymmetric Future</text>
+  <text x="490" y="355" font-size="9.5" fill="#5a8aa8">Both sides now have AI</text>
+</svg>

--- a/content/posts/os-weekly/os-weekly-2026-07-12.md
+++ b/content/posts/os-weekly/os-weekly-2026-07-12.md
@@ -19,6 +19,7 @@ categories: ["OS Weekly", "Threat Intelligence"]
 description: "This week: a compromised npm package drops an infostealer within minutes of publishing, CISA races federal agencies against an actively exploited Langflow flaw, and new research digs into AI's double-edged role in cybersecurity."
 slug: "os-weekly-2026-07-12"
 show_reading_time: true
+featured_image: /posts/os-weekly/images/os-weekly-2026-07-12-thumb.svg
 keywords: "poisoned npm package jscrambler infostealer, CISA Langflow authentication bypass patch, UAT-7810 LONGLEASH ORB network, supply chain security 2026, AI cybersecurity double edge, Kairos extortion no ransomware, NetNut Popa botnet FBI seizure, EU AI cybersecurity plan"
 faq:
   - q: "How did the jscrambler npm supply chain attack work?"


### PR DESCRIPTION
## Summary

Adds the banner images that were pushed after PR #163 was merged.

- `images/os-weekly-2026-07-12-thumb.svg` — 800×420 card used as `featured_image`
- `images/os-weekly-2026-07-12-hero.svg` — 1200×420 wide variant
- `featured_image` field added to the post's front matter

🤖 Generated with [Claude Code](https://claude.com/claude-code)