### PR TITLE
fix: inline sponsor placements in os-weekly-2026-07-12

### DIFF
--- a/content/posts/os-weekly/os-weekly-2026-07-12.md
+++ b/content/posts/os-weekly/os-weekly-2026-07-12.md
@@ -96,6 +96,12 @@ A Ransom-ISAC case study by Rakesh Krishnan traced roughly $1 million in payment
 
 [Read more →](https://thehackernews.com/2026/07/us-government-entity-paid-kairos-group.html)
 
+---
+
+**Sponsored:** Writing up this week's incident recaps or building a threat-model brief for your team? The [Canva cyber-themed content kit](https://www.canva.com/join/vqp-gcy-fgx) — dark-mode slides, hex accents, monospace vibes — is built for security folks who'd rather spend time on the content than the layout. Free to grab. _Affiliate link — signing up may support CyberShield at no extra cost to you._
+
+---
+
 ## Tools, Strategy & AI
 
 ### The asymmetric future of AI in cybersecurity
@@ -121,6 +127,12 @@ The European Commission announced a new initiative — targeting completion by 2
 Cisco Talos researchers drew a fun but genuinely useful parallel between tabletop strategy games and defensive security work, arguing that pattern recognition, adaptability, and — above all — curiosity are shared traits between good board-game players and good defenders. If you're early in your career, it's a good reminder that the "soft" skill of staying curious about how systems break is as valuable long-term as any single certification.
 
 [Read more →](https://blog.talosintelligence.com/catan-and-mouse/)
+
+---
+
+**Sponsored:** Mapping out your security career or building a CTF team page? [Carrd](https://try.carrd.co/trilltayo) is the lean, no-dark-patterns page builder that gets you live fast without fighting a CMS — good for portfolios, landing pages, and community hubs. _Affiliate link — signing up may support CyberShield at no extra cost to you._
+
+---
 
 ## Industry & People
 
@@ -156,6 +168,6 @@ That's the week. Stay curious, patch early, and keep questioning who's really be
 
 ## Sponsored
 
-**Canva (cyber-themed content kit):** If you're writing up incident recaps, threat-model briefs, or tool one-pagers, this free Canva kit — dark-mode slides, hex accents, monospace vibes — is built specifically for security folks who'd rather spend their time on the content than the layout. [Grab it here](https://www.canva.com/join/vqp-gcy-fgx). _Transparency: this is an affiliate link — if you sign up, it may support CyberShield at no extra cost to you._
+**Canva** — [cyber-themed content kit](https://www.canva.com/join/vqp-gcy-fgx) for security folks. Dark-mode slides, hex accents, monospace vibes. Free. _Affiliate link._
 
-**Carrd (portfolio & landing pages):** Building a personal site to showcase your security work or a CTF team page? Carrd is the lean, no-dark-patterns page builder we lean on when we want something live fast without fighting a CMS. [Check it out](https://try.carrd.co/trilltayo). _Transparency: this is an affiliate link — if you sign up, it may support CyberShield at no extra cost to you._
+**Carrd** — [portfolio & landing pages](https://try.carrd.co/trilltayo), live fast, no CMS required. _Affiliate link._


### PR DESCRIPTION
## Summary

Moves sponsors from end-only to mid-post placements for better visibility:

- **Canva** — inserted between Critical Threats and Tools/Strategy/AI sections (incident recaps / threat-model briefs context)
- **Carrd** — inserted before Industry & People (career/portfolio context, natural fit next to the Jen Ellis MBE story)
- Closing Sponsored section kept but trimmed to one-liners since both sponsors appear mid-post

🤖 Generated with [Claude Code](https://claude.com/claude-code)