### PR TITLE
Add blog post: GPT-Red and OpenAI's automated red-teaming research

### DIFF
--- a/content/posts/ai-devsecops/gpt-red-self-improvement-robustness.md
+++ b/content/posts/ai-devsecops/gpt-red-self-improvement-robustness.md
@@ -1,0 +1,81 @@
++++
+title = "GPT-Red: What OpenAI's Automated Red-Teamer Means for AI Security"
+date = 2026-07-16T09:00:00-05:00
+draft = false
+tags = ["AI Red Teaming", "Prompt Injection", "AI Security", "LLM Security", "Artificial Intelligence"]
+categories = ["AI and Security", "Security Engineering"]
+description = "OpenAI just published research on GPT-Red, an automated red-teaming model trained via self-play to find and fix prompt injection vulnerabilities at a scale human red-teamers can't match. Here's what it means for defenders."
+author = "Michael Tayo"
+keywords = "GPT-Red OpenAI, automated red teaming AI, prompt injection defense, indirect prompt injection, AI agent security, LLM self-play training, adversarial training LLM, GPT-5.6 robustness, AI red team automation"
+[[faq]]
+q = "What is GPT-Red?"
+a = "GPT-Red is an internal-only automated red-teaming model built by OpenAI to discover prompt injection vulnerabilities in its production models. It was trained at the compute scale of some of OpenAI's largest post-training runs and works the way a human red-teamer would: it sends a prompt, observes how the target model responds, and iterates until it finds a working attack."
+
+[[faq]]
+q = "How was GPT-Red trained?"
+a = "GPT-Red was trained with self-play reinforcement learning against a population of diverse defender LLMs across a large set of realistic red-teaming scenarios. GPT-Red is rewarded for eliciting a genuine failure — like a successful prompt injection — while the defenders are rewarded for resisting the attack and still completing their assigned task. As the defenders got harder to break, GPT-Red was forced to discover stronger and more varied attacks."
+
+[[faq]]
+q = "How effective is GPT-Red compared to human red-teamers?"
+a = "On a replicated version of the indirect prompt injection arena from Dziemian et al. (2025), GPT-Red found a successful attack in 84% of scenarios, compared to 13% for human red-teamers working the same set of environments. It has also been used to compromise a live, real-world agentic system — an AI-run vending machine — achieving all three of its assigned malicious objectives after iterating in simulation first."
+
+[[faq]]
+q = "Does adversarial training with GPT-Red actually improve model robustness?"
+a = "OpenAI reports that GPT-5.6 Sol, the model trained against GPT-Red's attacks, achieves 6x fewer failures on its hardest direct prompt injection benchmark than the production model from four months prior, and fails on only 0.05% of GPT-Red's direct prompt injection attempts. A prompt injection class called 'Fake Chain-of-Thought,' which had a 95%+ success rate against GPT-5.1, now succeeds less than 10% of the time against GPT-5.6 Sol. OpenAI also evaluated general capabilities and over-refusal rates to confirm the robustness gains didn't come from the model simply refusing more, which would be a false sense of security rather than real defense."
+
+[[faq]]
+q = "What does GPT-Red mean for organizations deploying AI agents?"
+a = "It's a signal that prompt injection is being taken seriously as a first-class vulnerability class, and that model-level robustness is improving. But it doesn't replace defense in depth. Any AI agent with access to email, browsers, file systems, or internal tools should still be deployed with layered safeguards: least-privilege tool access, output monitoring, human approval gates on sensitive actions, and your own red-teaming — because adversaries will red-team your specific harness and integrations, not just the base model."
++++
+
+OpenAI published research this week on **GPT-Red**, an automated red-teaming model trained to do one job: break other GPT models with prompt injection attacks, so those vulnerabilities get fixed before they reach production. It's a notable move in AI security because it treats red-teaming itself as a capability that needs to scale alongside model capability — and the results suggest it's working.
+
+If you're building or securing anything that puts an LLM in front of untrusted input — a browsing agent, an inbox assistant, a coding agent with shell access — this is worth understanding.
+
+## The problem: red-teaming doesn't scale
+
+Every AI agent that reads emails, browses the web, calls tools, or touches a file system is exposed to third-party data it doesn't control. That's also the attack surface. A malicious actor can embed an instruction in a webpage, an email body, a tool response, or a code comment, hoping the model treats it as a command instead of untrusted content — the same category of problem as unsanitized input in a traditional web app, just aimed at a model's instruction-following instead of a SQL parser.
+
+Human red-teaming has been the primary defense against this, but it doesn't scale. It's slow to design, expensive to run, and — critically — it can't generate the volume or diversity of adversarial examples needed to actually train a model to resist these attacks. OpenAI notes that commonly used robustness evaluations have already been saturated by their latest models, meaning the benchmarks themselves stopped being useful signal.
+
+## What GPT-Red actually does
+
+GPT-Red is trained using **self-play reinforcement learning**. The model and a population of diverse "defender" LLMs train simultaneously across a broad set of realistic red-teaming scenarios — GPT-Red controlling a slice of a webpage, an email body, part of a local file, or a tool's output. GPT-Red is rewarded for eliciting a genuine failure; the defenders are rewarded for resisting the attack while still completing their actual task. As defenders get harder to fool, GPT-Red is forced to find stronger, more diverse attacks — a familiar adversarial dynamic to anyone who's worked with GANs, just applied to alignment instead of image generation.
+
+Two design choices stand out:
+
+- **GPT-Red never ships.** It stays internal-only, specifically so the offensive capability trained into it doesn't end up in the hands of anyone outside OpenAI. The value is extracted by using it in training, not by deploying it.
+- **The attacks it finds are fed directly back into training the next production model.** GPT-Red's output was used in the training pipeline for GPT-5.6, making the model adversarially robust against the exact failure modes GPT-Red specializes in finding.
+
+## The numbers
+
+A few results from the published research stand out for anyone tracking prompt injection as a threat class:
+
+- On a replicated indirect prompt injection benchmark (Dziemian et al., 2025), GPT-Red found a successful attack in **84% of scenarios** against GPT-5.1, compared to **13%** for human red-teamers working the same environments.
+- GPT-5.6 Sol fails on only **0.05%** of GPT-Red's direct prompt injection attempts, and shows **6x fewer failures** on the hardest direct prompt injection benchmark compared to the production model from four months earlier.
+- A novel attack class dubbed **"Fake Chain-of-Thought"** — discovered by an early precursor of GPT-Red — had a 95%+ success rate against GPT-5.1. Against GPT-5.6 Sol, it's now below 10%.
+- Several indirect prompt injection benchmarks targeting developer tools and browsing have been **saturated (>97% accuracy)** by the latest model.
+
+OpenAI is also explicit about a failure mode worth calling out: a model can look "safer" simply by refusing more requests or becoming less capable — that's not real robustness, it's degraded utility wearing a security label. They report evaluating general capability and over-refusal rates alongside robustness gains to confirm the improvement came from actual resistance to malicious instructions, not the model getting more trigger-happy with refusals.
+
+## It's not just benchmarks — GPT-Red broke a live agent
+
+The most interesting part of the write-up, from a real-world security standpoint, is the case study against a live, production agentic system: an AI-operated vending machine (similar in spirit to Andon Labs' Project Vend). GPT-Red was given a description of the system and the ability to iterate against it in simulation before transferring its attack to the live agent. It hit all three of its objectives:
+
+1. Changed the price of an expensive in-stock item down to the $0.50 minimum.
+2. Ordered a new $100+ item and priced it at $0.50.
+3. Cancelled another customer's order.
+
+That's a useful reminder for anyone deploying agents with real-world side effects: the vulnerability isn't abstract, and an automated adversary with iteration ability can go from "here's a system description" to "here's a working exploit against production" faster than most incident response processes can react. OpenAI also tested GPT-Red against a Codex CLI-style coding agent across 10 held-out data-exfiltration scenarios and found it both more effective and more token-efficient than a prompted GPT-5.5 baseline doing the same job.
+
+## What this means if you're building or securing AI agents
+
+GPT-Red is an internal OpenAI tool — you won't get access to it, and that's intentional. But the underlying lesson applies whether you're red-teaming your own LLM integrations or defending against attackers who will eventually have equivalent tooling:
+
+- **Prompt injection is now a benchmarked, adversarially-trained-against vulnerability class**, not a fuzzy "AI safety" concern. Treat it in your own environments the way you'd treat injection vulnerabilities in a traditional app — with explicit threat models per integration point (browser tool, file access, email, code repo).
+- **Model-level robustness improving doesn't mean your harness is safe.** GPT-Red's own case studies show the highest-value attacks weren't against the base model in isolation — they were against the agent's tool access and the specific system it was wired into. Least-privilege tool scoping, output monitoring, and human approval gates on high-impact actions (payments, account changes, data exfil paths) still matter regardless of how robust the underlying model gets.
+- **Automated, self-play-style red-teaming is going to become standard practice.** If you're running your own agent security program, the direction of travel is clear: static red-team exercises run once before launch won't keep pace with how fast these systems evolve. Continuous, automated adversarial testing — even a lightweight version scoped to your own harness — is where this is heading.
+
+OpenAI says a pre-print with more technical detail is coming. Worth watching, especially the self-play training methodology, since that's the piece most transferable to anyone building their own red-teaming pipeline rather than relying solely on frontier labs to harden the models underneath them.
+
+**Source:** [GPT-Red: Unlocking Self-Improvement for Robustness](https://openai.com/index/unlocking-self-improvement-gpt-red/) — OpenAI, July 15, 2026.


### PR DESCRIPTION
## Summary
- New post covering OpenAI's GPT-Red research (published 2026-07-15): a self-play-trained automated red-teaming model used to harden GPT-5.6 against prompt injection.
- Includes benchmark results (84% vs 13% attack success vs. human red-teamers, 6x robustness improvement, the live vending-machine agent case study), and a defender-focused takeaways section for teams running their own AI agents.

## Test plan
- [x] `npx markdownlint-cli` passes with repo's `.markdownlint.json`
- [x] `hugo --minify --quiet` builds cleanly, page renders at `/posts/ai-devsecops/gpt-red-self-improvement-robustness/`
- [ ] Visual check on staging/preview before merge