### PR TITLE
fix: add banner SVG and inline images to gpt-red post

### DIFF
--- a/content/posts/ai-devsecops/gpt-red-self-improvement-robustness.md
+++ b/content/posts/ai-devsecops/gpt-red-self-improvement-robustness.md
@@ -1,38 +1,35 @@
-+++
-title = "GPT-Red: What OpenAI's Automated Red-Teamer Means for AI Security"
-date = 2026-07-16T09:00:00-05:00
-draft = false
-tags = ["AI Red Teaming", "Prompt Injection", "AI Security", "LLM Security", "Artificial Intelligence"]
-categories = ["AI and Security", "Security Engineering"]
-description = "OpenAI just published research on GPT-Red, an automated red-teaming model trained via self-play to find and fix prompt injection vulnerabilities at a scale human red-teamers can't match. Here's what it means for defenders."
-author = "Michael Tayo"
-keywords = "GPT-Red OpenAI, automated red teaming AI, prompt injection defense, indirect prompt injection, AI agent security, LLM self-play training, adversarial training LLM, GPT-5.6 robustness, AI red team automation"
-[[faq]]
-q = "What is GPT-Red?"
-a = "GPT-Red is an internal-only automated red-teaming model built by OpenAI to discover prompt injection vulnerabilities in its production models. It was trained at the compute scale of some of OpenAI's largest post-training runs and works the way a human red-teamer would: it sends a prompt, observes how the target model responds, and iterates until it finds a working attack."
-
-[[faq]]
-q = "How was GPT-Red trained?"
-a = "GPT-Red was trained with self-play reinforcement learning against a population of diverse defender LLMs across a large set of realistic red-teaming scenarios. GPT-Red is rewarded for eliciting a genuine failure — like a successful prompt injection — while the defenders are rewarded for resisting the attack and still completing their assigned task. As the defenders got harder to break, GPT-Red was forced to discover stronger and more varied attacks."
-
-[[faq]]
-q = "How effective is GPT-Red compared to human red-teamers?"
-a = "On a replicated version of the indirect prompt injection arena from Dziemian et al. (2025), GPT-Red found a successful attack in 84% of scenarios, compared to 13% for human red-teamers working the same set of environments. It has also been used to compromise a live, real-world agentic system — an AI-run vending machine — achieving all three of its assigned malicious objectives after iterating in simulation first."
-
-[[faq]]
-q = "Does adversarial training with GPT-Red actually improve model robustness?"
-a = "OpenAI reports that GPT-5.6 Sol, the model trained against GPT-Red's attacks, achieves 6x fewer failures on its hardest direct prompt injection benchmark than the production model from four months prior, and fails on only 0.05% of GPT-Red's direct prompt injection attempts. A prompt injection class called 'Fake Chain-of-Thought,' which had a 95%+ success rate against GPT-5.1, now succeeds less than 10% of the time against GPT-5.6 Sol. OpenAI also evaluated general capabilities and over-refusal rates to confirm the robustness gains didn't come from the model simply refusing more, which would be a false sense of security rather than real defense."
-
-[[faq]]
-q = "What does GPT-Red mean for organizations deploying AI agents?"
-a = "It's a signal that prompt injection is being taken seriously as a first-class vulnerability class, and that model-level robustness is improving. But it doesn't replace defense in depth. Any AI agent with access to email, browsers, file systems, or internal tools should still be deployed with layered safeguards: least-privilege tool access, output monitoring, human approval gates on sensitive actions, and your own red-teaming — because adversaries will red-team your specific harness and integrations, not just the base model."
-+++
+---
+title: "GPT-Red: What OpenAI's Automated Red-Teamer Means for AI Security"
+date: 2026-07-16
+draft: false
+author: "Michael Tayo"
+tags:
+  ["AI Red Teaming", "Prompt Injection", "AI Security", "LLM Security", "Artificial Intelligence"]
+categories: ["AI and Security", "Security Engineering"]
+description: "OpenAI just published research on GPT-Red, an automated red-teaming model trained via self-play to find and fix prompt injection vulnerabilities at a scale human red-teamers can't match. Here's what it means for defenders."
+show_reading_time: true
+featured_image: /posts/ai-devsecops/images/gpt-red-thumb.svg
+keywords: "GPT-Red OpenAI, automated red teaming AI, prompt injection defense, indirect prompt injection, AI agent security, LLM self-play training, adversarial training LLM, GPT-5.6 robustness, AI red team automation"
+faq:
+  - q: "What is GPT-Red?"
+    a: "GPT-Red is an internal-only automated red-teaming model built by OpenAI to discover prompt injection vulnerabilities in its production models. It was trained at the compute scale of some of OpenAI's largest post-training runs and works the way a human red-teamer would: it sends a prompt, observes how the target model responds, and iterates until it finds a working attack."
+  - q: "How was GPT-Red trained?"
+    a: "GPT-Red was trained with self-play reinforcement learning against a population of diverse defender LLMs across a large set of realistic red-teaming scenarios. GPT-Red is rewarded for eliciting a genuine failure — like a successful prompt injection — while the defenders are rewarded for resisting the attack and still completing their assigned task. As the defenders got harder to break, GPT-Red was forced to discover stronger and more varied attacks."
+  - q: "How effective is GPT-Red compared to human red-teamers?"
+    a: "On a replicated version of the indirect prompt injection arena from Dziemian et al. (2025), GPT-Red found a successful attack in 84% of scenarios, compared to 13% for human red-teamers working the same set of environments. It has also been used to compromise a live, real-world agentic system — an AI-run vending machine — achieving all three of its assigned malicious objectives after iterating in simulation first."
+  - q: "Does adversarial training with GPT-Red actually improve model robustness?"
+    a: "OpenAI reports that GPT-5.6 Sol, the model trained against GPT-Red's attacks, achieves 6x fewer failures on its hardest direct prompt injection benchmark than the production model from four months prior, and fails on only 0.05% of GPT-Red's direct prompt injection attempts. A prompt injection class called 'Fake Chain-of-Thought,' which had a 95%+ success rate against GPT-5.1, now succeeds less than 10% of the time against GPT-5.6 Sol. OpenAI also evaluated general capabilities and over-refusal rates to confirm the robustness gains didn't come from the model simply refusing more, which would be a false sense of security rather than real defense."
+  - q: "What does GPT-Red mean for organizations deploying AI agents?"
+    a: "It's a signal that prompt injection is being taken seriously as a first-class vulnerability class, and that model-level robustness is improving. But it doesn't replace defense in depth. Any AI agent with access to email, browsers, file systems, or internal tools should still be deployed with layered safeguards: least-privilege tool access, output monitoring, human approval gates on sensitive actions, and your own red-teaming — because adversaries will red-team your specific harness and integrations, not just the base model."
+---
 
 OpenAI published research this week on **GPT-Red**, an automated red-teaming model trained to do one job: break other GPT models with prompt injection attacks, so those vulnerabilities get fixed before they reach production. It's a notable move in AI security because it treats red-teaming itself as a capability that needs to scale alongside model capability — and the results suggest it's working.
 
 If you're building or securing anything that puts an LLM in front of untrusted input — a browsing agent, an inbox assistant, a coding agent with shell access — this is worth understanding.
 
 ## The problem: red-teaming doesn't scale
+
+![Illustration of automated pentesting limitations in cybersecurity](https://www.dropbox.com/scl/fi/18umm662t8it90jdanlgc/Automated-pentesting-limitations-in-cybersecurity..png?rlkey=t0lbfxfpv3enuv7luvrrbq6ch&raw=1)
 
 Every AI agent that reads emails, browses the web, calls tools, or touches a file system is exposed to third-party data it doesn't control. That's also the attack surface. A malicious actor can embed an instruction in a webpage, an email body, a tool response, or a code comment, hoping the model treats it as a command instead of untrusted content — the same category of problem as unsanitized input in a traditional web app, just aimed at a model's instruction-following instead of a SQL parser.
 
@@ -48,6 +45,8 @@ Two design choices stand out:
 - **The attacks it finds are fed directly back into training the next production model.** GPT-Red's output was used in the training pipeline for GPT-5.6, making the model adversarially robust against the exact failure modes GPT-Red specializes in finding.
 
 ## The numbers
+
+![Illustration of cybersecurity risk detection capabilities of GPT-5.5 and successor models](https://www.dropbox.com/scl/fi/yg99qf8kcsxsg1p68ipj1/Cybersecurity-risk-detection-by-GPT-5.5..png?rlkey=h7e6evo6p53fkx8mws3rhh5ku&raw=1)
 
 A few results from the published research stand out for anyone tracking prompt injection as a threat class:
 
@@ -69,6 +68,8 @@ The most interesting part of the write-up, from a real-world security standpoint
 That's a useful reminder for anyone deploying agents with real-world side effects: the vulnerability isn't abstract, and an automated adversary with iteration ability can go from "here's a system description" to "here's a working exploit against production" faster than most incident response processes can react. OpenAI also tested GPT-Red against a Codex CLI-style coding agent across 10 held-out data-exfiltration scenarios and found it both more effective and more token-efficient than a prompted GPT-5.5 baseline doing the same job.
 
 ## What this means if you're building or securing AI agents
+
+![Illustration of enhancing AI agents' cybersecurity skills and security posture](https://www.dropbox.com/scl/fi/1hus1ym57knkej6slo1n6/Enhancing-AI-agents-cybersecurity-skills.png?rlkey=c81h5uuwa1c2v646x9f5hj85v&raw=1)
 
 GPT-Red is an internal OpenAI tool — you won't get access to it, and that's intentional. But the underlying lesson applies whether you're red-teaming your own LLM integrations or defending against attackers who will eventually have equivalent tooling:
 

--- a/content/posts/ai-devsecops/images/gpt-red-thumb.svg
+++ b/content/posts/ai-devsecops/images/gpt-red-thumb.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 420" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0a0a14"/>
+      <stop offset="100%" stop-color="#130a1e"/>
+    </linearGradient>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1a0a2e" stroke-width="0.7"/>
+    </pattern>
+    <linearGradient id="redglow" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ef4444"/>
+      <stop offset="100%" stop-color="#a855f7"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="800" height="420" fill="url(#bg)"/>
+  <rect width="800" height="420" fill="url(#grid)"/>
+
+  <!-- Top accent — red/purple gradient for red-team theme -->
+  <rect x="0" y="0" width="800" height="4" fill="url(#redglow)"/>
+
+  <!-- Left bar -->
+  <rect x="52" y="56" width="4" height="254" rx="2" fill="#ef4444"/>
+
+  <!-- Category chip -->
+  <rect x="72" y="56" width="130" height="22" rx="11" fill="#1a0520" stroke="#ef4444" stroke-width="1"/>
+  <text x="137" y="71" text-anchor="middle" font-size="9.5" fill="#ef4444" letter-spacing="2" font-weight="600">AI RED TEAMING</text>
+  <text x="212" y="71" font-size="9.5" fill="#5a3a6a" letter-spacing="1">JUL 16, 2026</text>
+
+  <!-- Title -->
+  <text x="72" y="128" font-size="27" font-weight="800" fill="#f0e8ff" letter-spacing="-0.5">GPT-Red: OpenAI's</text>
+  <text x="72" y="166" font-size="27" font-weight="800" fill="#f0e8ff" letter-spacing="-0.5">Automated Red-Teamer</text>
+  <text x="72" y="204" font-size="27" font-weight="800" fill="#ef4444" letter-spacing="-0.5">vs. Prompt Injection</text>
+
+  <!-- Divider -->
+  <rect x="72" y="222" width="280" height="2" rx="1" fill="#2a1040"/>
+
+  <!-- Subtitle -->
+  <text x="72" y="250" font-size="14" fill="#9a7ab8">84% attack success rate. 6× fewer failures after training.</text>
+
+  <!-- Tags -->
+  <rect x="72" y="272" width="100" height="22" rx="11" fill="#110520" stroke="#ef4444" stroke-width="1"/>
+  <text x="122" y="287" text-anchor="middle" font-size="10" fill="#ef4444">Prompt Injection</text>
+
+  <rect x="180" y="272" width="78" height="22" rx="11" fill="#110520" stroke="#a855f7" stroke-width="1"/>
+  <text x="219" y="287" text-anchor="middle" font-size="10" fill="#a855f7">LLM Security</text>
+
+  <rect x="266" y="272" width="90" height="22" rx="11" fill="#110520" stroke="#f59e0b" stroke-width="1"/>
+  <text x="311" y="287" text-anchor="middle" font-size="10" fill="#f59e0b">AI Agents</text>
+
+  <!-- Branding -->
+  <text x="72" y="388" font-size="11" fill="#2a1040" letter-spacing="2.5">CYBERSECURITYOS.NET</text>
+
+  <!-- Right: stat cards -->
+  <rect x="476" y="58" width="256" height="70" rx="7" fill="#0f0520" stroke="#ef4444" stroke-width="1"/>
+  <rect x="476" y="58" width="4" height="70" fill="#ef4444"/>
+  <text x="490" y="77" font-size="8" fill="#ef4444" letter-spacing="1" font-weight="700">ATTACK SUCCESS RATE</text>
+  <text x="490" y="107" font-size="28" fill="#ef4444" font-weight="900" letter-spacing="-1">84%</text>
+  <text x="554" y="107" font-size="9.5" fill="#7a5a8a">vs 13% human red-teamers</text>
+
+  <rect x="476" y="138" width="256" height="70" rx="7" fill="#0f0520" stroke="#a855f7" stroke-width="1"/>
+  <rect x="476" y="138" width="4" height="70" fill="#a855f7"/>
+  <text x="490" y="157" font-size="8" fill="#a855f7" letter-spacing="1" font-weight="700">ROBUSTNESS IMPROVEMENT</text>
+  <text x="490" y="187" font-size="28" fill="#a855f7" font-weight="900" letter-spacing="-1">6×</text>
+  <text x="528" y="187" font-size="9.5" fill="#7a5a8a">fewer failures on GPT-5.6 Sol</text>
+
+  <rect x="476" y="218" width="256" height="70" rx="7" fill="#0f0520" stroke="#f59e0b" stroke-width="1"/>
+  <rect x="476" y="218" width="4" height="70" fill="#f59e0b"/>
+  <text x="490" y="237" font-size="8" fill="#f59e0b" letter-spacing="1" font-weight="700">FAKE CHAIN-OF-THOUGHT</text>
+  <text x="490" y="255" font-size="12.5" fill="#f0e8ff" font-weight="600">95% → &lt;10% success</text>
+  <text x="490" y="275" font-size="9.5" fill="#7a5a8a">GPT-5.1 vs GPT-5.6 Sol</text>
+
+  <rect x="476" y="298" width="256" height="70" rx="7" fill="#0f0520" stroke="#10b981" stroke-width="1"/>
+  <rect x="476" y="298" width="4" height="70" fill="#10b981"/>
+  <text x="490" y="317" font-size="8" fill="#10b981" letter-spacing="1" font-weight="700">LIVE AGENT BREACH</text>
+  <text x="490" y="335" font-size="12.5" fill="#f0e8ff" font-weight="600">AI Vending Machine</text>
+  <text x="490" y="355" font-size="9.5" fill="#7a5a8a">All 3 objectives achieved</text>
+</svg>


### PR DESCRIPTION
## Summary

- Created `gpt-red-thumb.svg` — dark red/purple themed banner (800×420) with the four key stats as cards: 84% attack success, 6× robustness improvement, Fake Chain-of-Thought 95%→<10%, live agent breach
- Added `featured_image` to front matter (converted from TOML to YAML to match site convention)
- Wired 3 Dropbox images inline at contextually matched sections:
  - **"Automated pentesting limitations"** → "The problem: red-teaming doesn't scale" section
  - **"Cybersecurity risk detection by GPT 5.5."** → "The numbers" section
  - **"Enhancing AI agents' cybersecurity skills"** → "What this means for defenders" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)