### PR TITLE
update: GPT-Red post — opinionated rewrite with thought-leader voice

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "snyk.advanced.autoSelectOrganization": true
+    "snyk.advanced.autoSelectOrganization": true,
+    "snyk.advanced.organization": "cbaf2cd1-52ba-473d-af75-002f3134604f"
 }

--- a/content/posts/ai-devsecops/gpt-red-self-improvement-robustness.md
+++ b/content/posts/ai-devsecops/gpt-red-self-improvement-robustness.md
@@ -23,60 +23,78 @@ faq:
     a: "It's a signal that prompt injection is being taken seriously as a first-class vulnerability class, and that model-level robustness is improving. But it doesn't replace defense in depth. Any AI agent with access to email, browsers, file systems, or internal tools should still be deployed with layered safeguards: least-privilege tool access, output monitoring, human approval gates on sensitive actions, and your own red-teaming — because adversaries will red-team your specific harness and integrations, not just the base model."
 ---
 
-OpenAI published research this week on **GPT-Red**, an automated red-teaming model trained to do one job: break other GPT models with prompt injection attacks, so those vulnerabilities get fixed before they reach production. It's a notable move in AI security because it treats red-teaming itself as a capability that needs to scale alongside model capability — and the results suggest it's working.
+OpenAI dropped research this week on **GPT-Red** — an automated red-teaming model built to break their own production models with prompt injection attacks before those attacks reach the real world. The headline numbers are impressive. But what actually interests me here isn't the 84% attack success rate or the 6× robustness improvement. It's what this research reveals about where the AI security field is, and how far most organizations are from actually being ready for any of this.
 
-If you're building or securing anything that puts an LLM in front of untrusted input — a browsing agent, an inbox assistant, a coding agent with shell access — this is worth understanding.
+Let me give you my honest read.
 
-## The problem: red-teaming doesn't scale
+## The 84% stat is an indictment, not a flex
 
 ![Illustration of automated pentesting limitations in cybersecurity](https://www.dropbox.com/scl/fi/18umm662t8it90jdanlgc/Automated-pentesting-limitations-in-cybersecurity..png?rlkey=t0lbfxfpv3enuv7luvrrbq6ch&raw=1)
 
-Every AI agent that reads emails, browses the web, calls tools, or touches a file system is exposed to third-party data it doesn't control. That's also the attack surface. A malicious actor can embed an instruction in a webpage, an email body, a tool response, or a code comment, hoping the model treats it as a command instead of untrusted content — the same category of problem as unsanitized input in a traditional web app, just aimed at a model's instruction-following instead of a SQL parser.
+The number that's getting the most attention: GPT-Red achieved an 84% attack success rate on indirect prompt injection scenarios, compared to 13% for human red-teamers working the same environments.
 
-Human red-teaming has been the primary defense against this, but it doesn't scale. It's slow to design, expensive to run, and — critically — it can't generate the volume or diversity of adversarial examples needed to actually train a model to resist these attacks. OpenAI notes that commonly used robustness evaluations have already been saturated by their latest models, meaning the benchmarks themselves stopped being useful signal.
+People are reading that as evidence of how powerful GPT-Red is. I'd flip it: it's evidence of how badly under-resourced AI red-teaming has been. Human red-teamers found working attacks in only 1 out of 8 scenarios. That's not a human limitation — that's what happens when you staff an emerging threat category with the same budget and tooling that worked for web app pentests in 2018.
 
-## What GPT-Red actually does
+We've been here before. For a long time, social engineering attacks were "not a real pentest concern" because they were hard to replicate at scale. Then phishing simulation platforms matured and suddenly everyone discovered their click rates were embarrassing. GPT-Red is doing the same thing for prompt injection — it's not creating a new problem, it's making an existing one impossible to ignore.
 
-GPT-Red is trained using **self-play reinforcement learning**. The model and a population of diverse "defender" LLMs train simultaneously across a broad set of realistic red-teaming scenarios — GPT-Red controlling a slice of a webpage, an email body, part of a local file, or a tool's output. GPT-Red is rewarded for eliciting a genuine failure; the defenders are rewarded for resisting the attack while still completing their actual task. As defenders get harder to fool, GPT-Red is forced to find stronger, more diverse attacks — a familiar adversarial dynamic to anyone who's worked with GANs, just applied to alignment instead of image generation.
+The question I'd be asking if I were running an AI security program right now: _what is your current prompt injection detection rate, and how do you know?_
 
-Two design choices stand out:
+## Self-play is the right idea — and the "never ships" constraint is also the right call, but think about what that means
 
-- **GPT-Red never ships.** It stays internal-only, specifically so the offensive capability trained into it doesn't end up in the hands of anyone outside OpenAI. The value is extracted by using it in training, not by deploying it.
-- **The attacks it finds are fed directly back into training the next production model.** GPT-Red's output was used in the training pipeline for GPT-5.6, making the model adversarially robust against the exact failure modes GPT-Red specializes in finding.
+GPT-Red works through self-play reinforcement learning: attacker and defender train simultaneously, each forcing the other to get better. The attacker is rewarded for finding real failures; the defender is rewarded for resisting while still completing its actual task. As defenders improve, the attacker is forced to discover more creative, more varied attacks.
 
-## The numbers
+This is exactly how you'd design this if you were serious about it. It's the same adversarial dynamic that made GAN-generated images so good — you can't brute-force quality, you have to evolve toward it.
+
+The design choice that matters most: GPT-Red never ships. It stays internal. OpenAI extracts the value through the training signal it generates, not by deploying it.
+
+That's the right call. But here's the part of this that keeps me up at night: adversaries building equivalent tooling are not going to make the same choice. When a criminal organization — or a nation-state — develops a comparable automated red-teamer, they're not going to hold it back for ethical reasons. They're going to deploy it against your production AI agents, continuously, at scale, while your security team is still scheduling quarterly red-team exercises.
+
+The gap between "OpenAI has this capability internally" and "defenders at most organizations have any equivalent capability" is not closing fast enough.
+
+## The numbers matter — but read them carefully
 
 ![Illustration of cybersecurity risk detection capabilities of GPT-5.5 and successor models](https://www.dropbox.com/scl/fi/yg99qf8kcsxsg1p68ipj1/Cybersecurity-risk-detection-by-GPT-5.5..png?rlkey=h7e6evo6p53fkx8mws3rhh5ku&raw=1)
 
-A few results from the published research stand out for anyone tracking prompt injection as a threat class:
+The robustness numbers on GPT-5.6 Sol are genuinely good:
 
-- On a replicated indirect prompt injection benchmark (Dziemian et al., 2025), GPT-Red found a successful attack in **84% of scenarios** against GPT-5.1, compared to **13%** for human red-teamers working the same environments.
-- GPT-5.6 Sol fails on only **0.05%** of GPT-Red's direct prompt injection attempts, and shows **6x fewer failures** on the hardest direct prompt injection benchmark compared to the production model from four months earlier.
-- A novel attack class dubbed **"Fake Chain-of-Thought"** — discovered by an early precursor of GPT-Red — had a 95%+ success rate against GPT-5.1. Against GPT-5.6 Sol, it's now below 10%.
-- Several indirect prompt injection benchmarks targeting developer tools and browsing have been **saturated (>97% accuracy)** by the latest model.
+- **6× fewer failures** on the hardest direct prompt injection benchmark vs. the production model from four months earlier
+- Fails on only **0.05%** of GPT-Red's direct prompt injection attempts
+- "**Fake Chain-of-Thought**" — a novel attack class with 95%+ success against GPT-5.1 — now hits below 10% against GPT-5.6 Sol
 
-OpenAI is also explicit about a failure mode worth calling out: a model can look "safer" simply by refusing more requests or becoming less capable — that's not real robustness, it's degraded utility wearing a security label. They report evaluating general capability and over-refusal rates alongside robustness gains to confirm the improvement came from actual resistance to malicious instructions, not the model getting more trigger-happy with refusals.
+OpenAI also did something I respect: they explicitly tested for over-refusal and capability degradation alongside the robustness gains. A model can fake "safer" by simply refusing more — that's not security, that's compliance theater wearing a security label. They confirmed the improvement came from actual resistance, not trigger-happiness. That's the kind of intellectual honesty that should be standard in AI safety reporting but rarely is.
 
-## It's not just benchmarks — GPT-Red broke a live agent
+That said, I want to be careful about what these numbers actually tell us. These are benchmarks designed and measured by the same team that built the system. That's not a criticism — it's just context. The real test is what happens when adversaries who didn't design the benchmark come looking.
 
-The most interesting part of the write-up, from a real-world security standpoint, is the case study against a live, production agentic system: an AI-operated vending machine (similar in spirit to Andon Labs' Project Vend). GPT-Red was given a description of the system and the ability to iterate against it in simulation before transferring its attack to the live agent. It hit all three of its objectives:
+## The vending machine is the most important thing in this paper
 
-1. Changed the price of an expensive in-stock item down to the $0.50 minimum.
-2. Ordered a new $100+ item and priced it at $0.50.
-3. Cancelled another customer's order.
+The case study everyone glossed over: GPT-Red was pointed at a live, production AI-operated vending machine. It got a description of the system, iterated against a simulation, and then transferred its attack to the live agent. It hit all three of its objectives — changed item prices, ordered new inventory at manipulated prices, cancelled a customer's order.
 
-That's a useful reminder for anyone deploying agents with real-world side effects: the vulnerability isn't abstract, and an automated adversary with iteration ability can go from "here's a system description" to "here's a working exploit against production" faster than most incident response processes can react. OpenAI also tested GPT-Red against a Codex CLI-style coding agent across 10 held-out data-exfiltration scenarios and found it both more effective and more token-efficient than a prompted GPT-5.5 baseline doing the same job.
+I keep seeing this framed as a cute demo. It isn't. It's a proof of concept for exactly how autonomous AI agents will be attacked in the real world: not through one brilliant prompt, but through iteration. An attacker describes your system, builds a simulation, and runs automated attacks until something works. Then they move to production.
 
-## What this means if you're building or securing AI agents
+The vending machine is low stakes. Now mentally substitute your AI agent that processes customer refunds. Or approves expense reports. Or has read/write access to your code repository. The attack methodology scales identically.
+
+What's the iteration budget on your incident response process? Because an automated adversary can run hundreds of attack variations overnight.
+
+## What I'd actually do if I were you
 
 ![Illustration of enhancing AI agents' cybersecurity skills and security posture](https://www.dropbox.com/scl/fi/1hus1ym57knkej6slo1n6/Enhancing-AI-agents-cybersecurity-skills.png?rlkey=c81h5uuwa1c2v646x9f5hj85v&raw=1)
 
-GPT-Red is an internal OpenAI tool — you won't get access to it, and that's intentional. But the underlying lesson applies whether you're red-teaming your own LLM integrations or defending against attackers who will eventually have equivalent tooling:
+GPT-Red is not something you'll get access to. OpenAI made that choice deliberately. But the underlying threat — automated, iterative prompt injection against your specific agent harness — is coming regardless of whether the tool is publicly available.
 
-- **Prompt injection is now a benchmarked, adversarially-trained-against vulnerability class**, not a fuzzy "AI safety" concern. Treat it in your own environments the way you'd treat injection vulnerabilities in a traditional app — with explicit threat models per integration point (browser tool, file access, email, code repo).
-- **Model-level robustness improving doesn't mean your harness is safe.** GPT-Red's own case studies show the highest-value attacks weren't against the base model in isolation — they were against the agent's tool access and the specific system it was wired into. Least-privilege tool scoping, output monitoring, and human approval gates on high-impact actions (payments, account changes, data exfil paths) still matter regardless of how robust the underlying model gets.
-- **Automated, self-play-style red-teaming is going to become standard practice.** If you're running your own agent security program, the direction of travel is clear: static red-team exercises run once before launch won't keep pace with how fast these systems evolve. Continuous, automated adversarial testing — even a lightweight version scoped to your own harness — is where this is heading.
+Here's where I'd focus:
 
-OpenAI says a pre-print with more technical detail is coming. Worth watching, especially the self-play training methodology, since that's the piece most transferable to anyone building their own red-teaming pipeline rather than relying solely on frontier labs to harden the models underneath them.
+**Stop treating prompt injection as a model problem.** The most dangerous attacks in this research weren't against the base model in isolation — they were against the agent's tool access and the system it was wired into. A more robust model running inside an over-privileged, under-monitored harness is still a sitting target. Least-privilege tool scoping is more durable protection than waiting for the next model update.
+
+**Build threat models per integration point, not per deployment.** Every place your agent touches untrusted data — email body, web page, file content, API response, database record — is a distinct attack surface with its own risk profile. A generic "we have prompt injection defenses" statement covers none of them specifically. Map them explicitly. I've seen too many AI security reviews that evaluate the model and skip the system.
+
+**Accept that your red-team cadence is already out of date.** Quarterly red-team exercises made sense when your attack surface changed quarterly. AI agents update faster than that, integrate with more data sources than that, and will face adversaries who iterate faster than that. Continuous, automated adversarial testing scoped to your specific harness is where this has to go — not next year, not when your budget allows. Now, with whatever you have.
+
+**Watch for the pre-print.** OpenAI mentioned that more technical detail on the self-play training methodology is coming. That's the part most transferable to organizations building their own red-teaming pipelines — and it's worth understanding before your adversaries do.
+
+---
+
+The broader pattern here is one I've been watching for a while: frontier AI labs are developing security capabilities at a pace and scale that no individual organization can match internally. That asymmetry is only going to grow. The strategic question for every security leader isn't "how do we build our own GPT-Red" — it's "how do we build security programs that account for the fact that our attackers will eventually have access to equivalent tooling, and act accordingly."
+
+Most of us aren't there yet. That's the actual takeaway.
 
 **Source:** [GPT-Red: Unlocking Self-Improvement for Robustness](https://openai.com/index/unlocking-self-improvement-gpt-red/) — OpenAI, July 15, 2026.


### PR DESCRIPTION
## Summary

- Rewrites the GPT-Red post body from a neutral AI-summary style to an opinionated, thought-leader voice
- Adds contrarian takes throughout (e.g., "the 84% stat is an indictment, not a flex")
- Renames sections to sharper headlines; adds personal framing ("keeps me up at night")
- Elevates the vending machine case study as the most important takeaway
- Replaces neutral bullet points in "what to do" with first-person directives
- Fixes MD026 markdownlint warning (removed trailing punctuation from heading)
- Retains all three Dropbox inline images and the SVG featured image from the prior PR

## Test plan

- [ ] `npm run lint:md` passes with no warnings
- [ ] `npx prettier --check` passes
- [ ] `hugo --quiet` builds without errors
- [ ] Post reads with distinct POV — not a plain summary of the source blog

🤖 Generated with [Claude Code](https://claude.com/claude-code)