### PR TITLE
Fix: integrate sponsor mentions natively in OS Weekly 2026-07-19

### DIFF
--- a/content/posts/os-weekly/os-weekly-2026-07-19.md
+++ b/content/posts/os-weekly/os-weekly-2026-07-19.md
@@ -45,7 +45,7 @@ It's been a loud week. A ransomware crew chained two "moderate" SonicWall bugs i
 
 Threat actors are combining two vulnerabilities in SonicWall's Secure Mobile Access appliances — one rooted in improper security controls, the other in insufficient input validation — to get root-level access on affected devices. Neither flaw looks especially dangerous by itself, which is exactly the point: chained together, they hand attackers full control of the box.
 
-It's a good reminder that severity scoring doesn't always capture real-world risk. Two "moderate" bugs in the same product line can add up to a critical compromise path. If SonicWall SMA appliances are in your environment, prioritize the vendor's guidance now — don't wait for a CVSS number to justify the urgency.
+It's a good reminder that severity scoring doesn't always capture real-world risk. Two "moderate" bugs in the same product line can add up to a critical compromise path. If SonicWall SMA appliances are in your environment, prioritize the vendor's guidance now — don't wait for a CVSS number to justify the urgency. If you need to walk leadership through how the chain actually works, a simple kill-chain diagram does more than a paragraph of prose — we sketch ours in [Canva](https://www.canva.com/join/vqp-gcy-fgx) (affiliate link) when a whiteboard photo won't cut it for the incident report.
 
 [Read more →](https://www.darkreading.com/vulnerabilities-threats/inc-ransomware-exploits-sonicwall-sma-zero-days)
 
@@ -137,7 +137,7 @@ Beyond the specific products — worth checking against your dependency tree if 
 
 The White House announced a new clearinghouse meant to centralize threat intelligence sharing around AI-driven attacks, connecting government agencies, private-sector partners, and international allies. The goal is more coordinated, faster responses to AI-enabled threats instead of every stakeholder working from a partial picture.
 
-For anyone building a career in this field, initiatives like this are worth tracking — they tend to shape where funding, hiring, and policy attention flow over the following year.
+For anyone building a career in this field, initiatives like this are worth tracking — they tend to shape where funding, hiring, and policy attention flow over the following year. It's also as good a nudge as any to make sure your own work is easy to find: if your CTF writeups, certs, or research are still scattered across random links, a quick [Carrd](https://try.carrd.co/trilltayo) page (affiliate link) gets them in front of the people making those hiring calls without you standing up a full site.
 
 [Read more →](https://www.cnn.com/2026/07/14/tech/ai-cybersecurity-clearing-house-white-house)
 
@@ -180,11 +180,3 @@ Israeli startup Oak, co-founded by Shai Morag, stepped out of stealth with $60 m
 ---
 
 That's the week. Patch what you can, question the provenance of the tools and vendors you trust, and keep stacking skills one CVE at a time. Follow CyberShield for next Sunday's roundup.
-
----
-
-## Sponsored
-
-**Canva** — [cyber-themed content kit](https://www.canva.com/join/vqp-gcy-fgx) for building clean IR playbooks, kill-chain diagrams, and briefing decks in minutes instead of hours. _Affiliate link._
-
-**Carrd** — [portfolio & landing pages](https://try.carrd.co/trilltayo) for showcasing your CTF writeups, certs, or research — no full CMS required. _Affiliate link._


### PR DESCRIPTION
## Summary
- The Canva/Carrd sponsor mentions were previously dumped in a standalone "## Sponsored" section at the bottom of the post — this weaves each one contextually into the story it's most relevant to instead.
- Canva now appears inline in the SonicWall ransomware-chain story, as a suggestion for visualizing the kill chain in an incident report.
- Carrd now appears inline in the White House AI clearinghouse story, tied to the existing "build your career" advice.
- Both keep an inline `(affiliate link)` disclosure next to the link itself, rather than a separate disclosure paragraph.
- Removed the now-empty standalone Sponsored section.

## Test plan
- [x] `npm run lint:md`
- [x] `npm run lint:format`
- [x] `hugo --quiet` builds clean